### PR TITLE
Add rubocop and bundler-audit rake tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@
 
 source 'https://rubygems.org'
 
+gem 'bundler-audit', require: false
 gem 'cucumber'
 gem 'eventually_helper'
 gem 'page-object'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,9 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     ast (2.4.1)
     builder (3.2.4)
+    bundler-audit (0.7.0.1)
+      bundler (>= 1.2.0, < 3)
+      thor (>= 0.18, < 2)
     childprocess (3.0.0)
     concurrent-ruby (1.1.6)
     cucumber (4.1.0)
@@ -126,6 +129,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bundler-audit
   cucumber
   eventually_helper
   page-object

--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,24 @@
 # frozen_string_literal: true
 
-require 'rubygems'
+require 'bundler/audit/task'
 require 'cucumber'
 require 'cucumber/rake/task'
+require 'rubocop/rake_task'
+require 'rubygems'
 
+# Add Ins
+Bundler::Audit::Task.new
+RuboCop::RakeTask.new
+
+# Custom Tasks
+desc 'Run rubocop and bundler-audit'
+task :checks do
+  Rake::Task['rubocop'].invoke
+  Rake::Task['bundle:audit'].invoke
+end
+
+# Set (Cucumber) features as default
 Cucumber::Rake::Task.new(:features) do |t|
   t.profile = 'default'
 end
-
 task default: :features

--- a/docker-compose.checks.yml
+++ b/docker-compose.checks.yml
@@ -1,0 +1,8 @@
+version: '2.1'
+services:
+  browsertests_checks:
+    build: .
+    container_name: sample-login-watir-cucumber
+    volumes:
+      - .:/app
+    command: bundle exec rake checks


### PR DESCRIPTION


This change adds...
 - `rubocop` rake task
 - `bundler-audit` rake task
 -  custom `checks` rake task that runs both `rubocop` and `bundler-audit` tasks 
 - adds a docker-compose file (docker-compose.checks.yml) for running the `checks` rake task in the container

To run the `checks` test in a container...
```
$ docker-compose -f docker-compose.checks.yml up
```