### PR TITLE
Add Github Ruby Workflow to run rubocop and bundler-audit checks

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,32 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: Ruby
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+    # change this to (see https://github.com/ruby/setup-ruby#versioning):
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.6.3
+    - name: Install dependencies
+      run: bundle install
+    - name: Run checks
+      run: bundle exec rake checks


### PR DESCRIPTION
This adds the `.github/workflows/ruby.yml` file which specifies the github ruby (project) workflow.  This workflow runs this project's custom `checks` rake task which runs `rubocop` and `bundler-audit` rake tasks.

This was tested by having this commit pass both of the checks and by having a rubocop violation commit fail the checks.
