### PR TITLE
Renaming GitHub Workflow 

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,7 +14,7 @@ on:
     branches: [ master ]
 
 jobs:
-  test:
+  rubocop-bundler-audit:
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
 to `rubocop-bundler-audit` from `test`