### PR TITLE
Adding Basic Docker Dev Environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,42 +1,48 @@
 # sample-login-watir-cucumber
 ### Builder Stage ###
 FROM ruby:2.6.6-alpine AS builder
-
 # Need to add lib-ffi to build ffi gem native extensions
 RUN apk --update add --virtual build-dependencies build-base libffi-dev
 
 # Use the same version of Bundler in the Gemfile.lock
 RUN gem install bundler -v 2.1.4
-
 WORKDIR /app
-
 # Install the Ruby dependencies (defined in the Gemfile/Gemfile.lock)
 COPY Gemfile Gemfile.lock ./
 RUN bundle install
 
 ### Lint Stage ###
 FROM builder AS lint
-CMD bundle exec rake rubocop
+COPY . .
+RUN bundle exec rake rubocop
 
 ### Security Static Scan Stage ###
 # Keep build dependencies
 FROM builder AS secscan
-
 # Add git for bundler-audit
 RUN apk add --no-cache git
+# Just need Rakefile and Gemfile.lock
+COPY Rakefile ./
+RUN bundle exec rake bundle:audit
 
-CMD bundle exec rake bundle:audit
+### Dev Environment Stage ###
+FROM secscan AS devenv
+# Add vim at least
+RUN apk add --no-cache vim
+CMD /bin/ash
 
 ### Deploy Stage ###
 FROM ruby:2.6.6-alpine AS deploy
-
 # Throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1
 
-# Copy over the built gems directory from builder image
-COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
+RUN adduser -D deployer
+USER deployer
 
-# Copy in copy instead from mounted volume
+# Copy over the built gems directory from builder image
+COPY --from=builder --chown=deployer /usr/local/bundle/ /usr/local/bundle/
+# Copy in app source
+WORKDIR /app
 COPY . .
 
 # To Run the tests - altho this is orchestrated by the docker-compose.yml file

--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ to be already running on the default ports)
 to be already running on the default ports)
 * `firefox` - Mozilla Firefox (requires Firefox)
 * `firefox_headless` - Mozilla Firefox (requires Firefox)
-* `firefox_container` = Selenium Standalone Chrome Debug container (requires this container 
+* `firefox_container` - Selenium Standalone Chrome Debug container (requires this container 
 to be already running on the default ports)
-* `firefox_headless_container` = Selenium Standalone Chrome Debug container (requires this container 
+* `firefox_headless_container` - Selenium Standalone Chrome Debug container (requires this container 
 to be already running on the default ports)
 * `safari` - Apple Safari (requires Safari)
 
@@ -181,6 +181,35 @@ Install gems (from project root):
 
 ```
 $ bundle
+```
+
+## Development
+This project can be developed locally or using the supplied basic,
+container-based development environment which include `vim` and `git`.
+
+### To Develop Using the Container-based Development Environment
+To develop using the supplied container-based development environment...
+1. Build the development environment image specifying the `devenv` build
+   stage as the target and supplying a name (tag) for the image.
+```
+docker build --no-cache --target devenv -t browsertests-dev .
+```
+2. Run the built development environment image either on its own or
+in the docker-compose environment with either the Selenium Chrome
+or Firefox container.  By default the development environment container
+executes the `/bin/ash` shell providing a command line interface. When
+running the development environment container, you must specify the path
+to this project's source code.
+
+To run the development environment on its own, use `docker run`...
+```
+docker run -it --rm -v $(pwd):/app browsertests-dev
+```
+
+To run the development environment in the docker-compose environment,
+use the `docker-compose.dev.yml` file...
+```
+IMAGE=browsertests-dev SRC=${PWD} docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.seleniumchrome.yml run browsertests /bin/ash
 ```
 
 ## Additional Information

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,7 @@
+version: '3.4'
+services:
+  browsertests:
+    image: "${IMAGE}"
+    container_name: "sample-login-watir-cucumber-${IMAGE}"
+    volumes:
+      - ${SRC}:/app


### PR DESCRIPTION
Add a basic docker dev environment
- Separate Dockerfile build stage with builder, git, and vim
`docker build --no-cache --target devenv -t testz-dev .`
`docker run -it --rm -v $(pwd):/app testz-dev`

- (Overide) docker-compose.dev.yml file with env-specifiable image instead of build
`IMAGE=testz-dev SRC=${PWD} docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.seleniumchrome.yml run browsertests /bin/ash`

- modifiable source code mounted into dev image

- fixes to `Dockerfile` to have dependencies and to now run the lint and secscan checks as part of build

