### PR TITLE
Refactor Remote Browser Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # sample-login-watir-cucumber
 
-This is an example 
-[Watir](http://watir.com)-[Cucumber](https://cucumber.io)-[Ruby](https://www.ruby-lang.org)
-implementation of Acceptance Test Driven Development (ATDD).
+This is an example of Acceptance Test Driven Development (ATDD) using
+[Watir](http://watir.com), [Cucumber](https://cucumber.io), [Ruby](https://www.ruby-lang.org).
 **However, it also provides a somewhat extensible framework that can be reused
 by replacing the existing tests.**
 
@@ -36,6 +35,7 @@ a Selenium Standalone container.
 You must have docker installed and running on your local machine.
 
 ### To Run Fully in Docker
+#### To Run Using the Chrome Standalone Container
 1. Ensure Docker is running
 2. Run the project docker-compose.yml file with the
    docker-compose.seleniumchrome.yml file (this runs using the Chrome
@@ -45,6 +45,7 @@ docker-compose -f docker-compose.yml -f docker-compose.seleniumchrome.yml up
 ```
 
 #### To Run Using the Firefox Standalone Container
+1. Ensure Docker is running
 2. Run the project docker-compose.yml file (this runs using the Firefox
    standalone container
 ```
@@ -65,10 +66,10 @@ bundle exec cucumber
 ```
 #### Browsers ####
 ```
-SPEC_BROWSER=chrome bundle exec rake
+BROWSER=chrome bundle exec rake
 ```
 ```
-SPEC_BROWSER=firefox_headless_container bundle exec cucumber
+BROWSER=firefox_headless bundle exec cucumber
 ```
 
 ### To Run Using Rake
@@ -82,8 +83,17 @@ To run the automated tests using Cucumber, execute...
 *command-line-arguments* `bundle exec cucumber`
 
 ### Command Line Arguments
+#### Specify Remote (Container) URL
+`REMOTE=`...
+
+Specifying a Remote URL creates a remote browser of type
+specified by `BROWSER` at the specified remote URL  
+
+ **Example:**
+`REMOTE='http://localhost:4444/wd/hub'`
+
 #### Specify Browser
-`SPEC_BROWSER=`...
+`BROWSER=`...
 
 * Mostly, this uses a pass thru and convert to symbol approach
   * **example:** "chrome" converts to `:chrome` which is a Watir browser
@@ -91,7 +101,6 @@ To run the automated tests using Cucumber, execute...
 and sending that as an argument to the browser specified
   * **example:** "chrome_headless" converts to `:chrome`
   with `headless` argument
-* Container based browsers are handled by detecting the word "container"
 
 #### Browser Drivers
 This project uses the
@@ -103,21 +112,9 @@ geckodriver (Firefox).
 The following browsers were working on Mac at the time of this commit:
 * `chrome` - Google Chrome (requires Chrome)
 * `chrome_headless` - Google Chrome run in headless mode (requires Chrome > 59)
-* `chrome_container` - Selenium Standalone Chrome Debug container (requires this container 
-to be already running on the default ports)
-* `chrome_headless_container` - Selenium Standalone Chrome Debug container (requires this container 
-to be already running on the default ports)
 * `firefox` - Mozilla Firefox (requires Firefox)
 * `firefox_headless` - Mozilla Firefox (requires Firefox)
-* `firefox_container` - Selenium Standalone Chrome Debug container (requires this container 
-to be already running on the default ports)
-* `firefox_headless_container` - Selenium Standalone Chrome Debug container (requires this container 
-to be already running on the default ports)
 * `safari` - Apple Safari (requires Safari)
-
-
-*R.I.P.* `phantomjs` - PhantomJS headless browser is no longer supported by Watir
-(although I can no longer seem to find the link)
 
 ### To Run Using the Selenium Standalone Debug Containers
 These tests can be run using the Selenium Standalone Debug containers for both
@@ -140,9 +137,10 @@ for the VNC server
 docker run -d -p 4444:4444 -p 5900:5900 -v /dev/shm:/dev/shm selenium/standalone-chrome-debug:latest
 ```
 3. Wait for the Selenium Standalone Chrome Debug container to be running (e.g. 'docker ps')
-4. Run the tests using the `chrome_container`
+4. Run the tests specifing the `REMOTE` and using the `chrome` or `chrome_headless` browser
+   specification
 ```
-SPEC_BROWSER=chrome_container bundle exec cucumber
+REMOTE='http://localhost:4444/wd/hub' BROWSER=chrome bundle exec cucumber
 ```
 
 #### To Run Using Selenium Standalone Firefox Debug Container
@@ -153,9 +151,10 @@ for the VNC server
 docker run -d -p 4444:4444 -p 5900:5900 -v /dev/shm:/dev/shm selenium/standalone-firefox-debug:latest
 ```
 3. Wait for the Selenium Standalone Firefox Debug container to be running (e.g. 'docker ps')
-4. Run the tests using the `firefox_container`
+4. Run the tests specifying the `REMOTE` and using the `firefox` or `firefox_headless` browser
+   specification
 ```
-SPEC_BROWSER=firefox_headless_container bundle exec cucumber
+REMOTE='http://localhost:4444/wd/hub' BROWSER=firefox_headless bundle exec cucumber
 ```
 
 #### To See the Tests Run Using the VNC Server

--- a/docker-compose.seleniumchrome.yml
+++ b/docker-compose.seleniumchrome.yml
@@ -2,8 +2,8 @@ version: '3.4'
 services:
   browsertests:
     environment:
-      - SPEC_BROWSER=chrome_container
-      - CONTAINER=seleniumchrome
+      - BROWSER=chrome
+      - REMOTE=http://seleniumchrome:4444/wd/hub
     command: ./script/runtests
     depends_on:
       - seleniumchrome

--- a/docker-compose.seleniumfirefox.yml
+++ b/docker-compose.seleniumfirefox.yml
@@ -2,8 +2,8 @@ version: '3.4'
 services:
   browsertests:
     environment:
-      - SPEC_BROWSER=firefox_container
-      - CONTAINER=seleniumfirefox
+      - BROWSER=firefox
+      - REMOTE=http://seleniumfirefox:4444/wd/hub
     command: ./script/runtests
     depends_on:
       - seleniumfirefox

--- a/script/runtests
+++ b/script/runtests
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 COUNTER=0
-REMOTE_BROWSER="http://${CONTAINER}:4444/wd/hub/status"
-echo "Waiting for ${REMOTE_BROWSER} to become available"
-until wget --spider -q "${REMOTE_BROWSER}" &>/dev/null; do
+REMOTE_STATUS="${REMOTE}/status"
+echo "Waiting for ${REMOTE_STATUS} to become available"
+until wget --spider -q "${REMOTE_STATUS}" &>/dev/null; do
   printf "."
   sleep 1
   COUNTER=$((COUNTER + 1))


### PR DESCRIPTION
## Refactor Remote Browser Handling
**What:** Refactor the browser handling to add more ability and flexibility, specifically with remote browsers (e.g. now supports headless remote browsers)
**Why:** More flexibility in adding remote containers by being able to fully specify URL
**More Info...**
- Pass in the full remote browser URL instead of just the docker-compose service name
  - Rename `CONTAINER` environment variable to `REMOTE`
- Rename `SPEC_BROWSER` environment variable to `BROWSER`
- Add support for running headless (chrome and firefox) browser containers
- Refactor browser handling to be hopefully cleaner and clearer
  - Made explicit that `REMOTE` takes precedence and split single browser creation method into local and remote
  - Remove specification of  `chrome_container` , `chrome_headless_container`, `firefox_container`, 
     `firefox_headless_container`

### Testing
#### Code Paths Impacted and Testing Scope
- All environment variables renamed so all specification (used in automation and orchestration) impacted
- All browser creation impacted - local (default and specified including headless) and remote (container and docker-compose)
  - BUT browser specification e.g. `name_headless` is "pass thru" and does not depend on browser specified - if one instance works, they all will logically

#### Tests
##### Using automated CI/CD pipeline of PR...
- `git push` - verifies github workflows, orchestrated docker compose of `rake runchecks` (rubocop, bundler-audit), chrome and firefox remote containers and runtests script (environment variable changes and remote non-headless containers)

##### Using `README` to verify documentation and record test cases in future
**Local**
These tests cases are sufficient equivalence classes to cover all local browser change coverage
1. `bundle exec rake` - verifies local (Watir) default browser creation path
2. `BROWSER=chrome bundle exec rake` - verifies specifying non-headless valid local browser
3. `BROWSER=firefox_headless bundle exec cucumber` - verifies specifying headless valid local browser

** Remote **
 For the most part (the specific docker-compose orchestration is different) the PR CI/CD process verifies and applies here...
1. `docker-compose -f docker-compose.yml -f docker-compose.seleniumchrome.yml up` -< verifies a remote valid browser
2. `docker-compose -f docker-compose.yml -f docker-compose.seleniumfirefox.yml up`

Leaving...
1. `docker run -d -p 4444:4444 -p 5900:5900 -v /dev/shm:/dev/shm selenium/standalone-firefox-debug:latest` && `REMOTE='http://localhost:4444/wd/hub' BROWSER=chrome bundle exec cucumber` - verifies documentation change and VNC server and non-headless valid browser
2. `docker run -d -p 4444:4444 -p 5900:5900 -v /dev/shm:/dev/shm selenium/standalone-chrome-debug:latest` && `REMOTE='http://localhost:4444/wd/hub' BROWSER=firefox_headless bundle exec cucumber` - verifies documentation change and headless valid browser (use VNC server)