### PR TITLE
Change docker-compose to Use SeleniumHQ Healthcheck

### DIFF
--- a/docker-compose.seleniumchrome.yml
+++ b/docker-compose.seleniumchrome.yml
@@ -11,10 +11,11 @@ services:
   seleniumchrome:
     image: selenium/standalone-chrome:latest
     container_name: selenium-chrome
+    shm_size: 2gb
     volumes:
       - /dev/shm:/dev/shm
     healthcheck:
-      test: ["CMD-SHELL", "curl --silent --fail -X HEAD http://localhost:4444/wd/hub"]
-      interval: 2s
-      timeout: 5s
-      retries: 30
+      test: ["CMD-SHELL", '/opt/bin/check-grid.sh --host 0.0.0.0 --port 4444']
+      interval: 15s
+      timeout: 30s
+      retries: 5

--- a/docker-compose.seleniumfirefox.yml
+++ b/docker-compose.seleniumfirefox.yml
@@ -11,10 +11,11 @@ services:
   seleniumfirefox:
     image: selenium/standalone-firefox:latest
     container_name: selenium-firefox
+    shm_size: 2gb
     volumes:
       - /dev/shm:/dev/shm
     healthcheck:
-      test: ["CMD-SHELL", "curl --silent --fail -X HEAD http://localhost:4444/wd/hub"]
-      interval: 2s
-      timeout: 5s
-      retries: 30
+      test: ["CMD-SHELL", '/opt/bin/check-grid.sh --host 0.0.0.0 --port 4444']
+      interval: 15s
+      timeout: 30s
+      retries: 5


### PR DESCRIPTION
# Change docker-compose to Use SeleniumHQ Healthcheck #34
This change updates the `docker-compose-selenium[chrome|firefox].yml` files to use the [ healthcheck script](https://github.com/SeleniumHQ/docker-selenium#adding-a-healthcheck-to-the-grid) provided in the SeleniumHQ browser images.

## Changes and Impacts
The `docker-compose-selenium[chrome|firefox].yml` files were changed to use the SeleniumHQ healthcheck script
instead of a curl command.  This only impacts the docker-compose orchestration when using the browser containers.

## Testing

- Although it was tested locally, the PR checks vet the changes to the docker-compose orchestration with the Chrome
   and Firefox containers
- In addition, the Chrome and Firefox containers were started using the docker-compose orchestration and a 
   `docker-compose ps` was performed to verify that the healthchecks were reporting the containers as healthy