### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+# What
+> Describe at a high level what changes are in this Pull Request.
+>
+> Delete this callout.
+
+# Why
+> Describe why your are making these changes especially their value.
+>
+> Delete this callout.
+
+# Change Impact Analysis and Testing
+> Describe the specific impacts of your changes and how those impacts
+> will be vetted.
+>
+> Delete this callout.


### PR DESCRIPTION
# What
This non-functional change simply adds a Pull Request (PR) template per https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository.

# Why
Adds a basic template for PRs to this project to save time and provide some basic consistency.

# Change Impact Analysis and Testing
Since this is a non-functional change only the added PR template needs vetting.

This PR template was tested (since I can not fork my own repository) by going to the added file under the branch  (https://github.com/brianjbayer/sample-login-watir-cucumber/blob/add-pr-template/.github/pull_request_template.md), using the **Copy raw contents** button to copy the file, pasting it into this PR's **Description**, and visually inspecting it.