### PR TITLE
Refactor Headless Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This framework contains support for...
 * Using Selenium Standalone containers eliminating the need
   for locally installed browsers or drivers
 * Multiple local browsers with automatic driver management
+* Headless execution for those browsers that support it
 * Single-command docker-compose framework to run
   the tests or a supplied command
 * Native through fully-containerized execution
@@ -51,7 +52,7 @@ You must have Docker installed and running on your local machine.
 
 ### To See the Tests Run Using the VNC Server
 > Browsers in the containers are not visible in the VNC server
-  when running `headless`.
+> when running headless
 
 The Selenium Standalone containers used in the docker-compose
 framework have an included VNC server for viewing and
@@ -138,26 +139,37 @@ Chrome be installed).
 **Example:**
 `BROWSER=chrome`
 
-> * Mostly, this uses a pass thru and convert to symbol approach
->   * **example:** "chrome" converts to `:chrome` which is a Watir browser
-> * Headless browsers are handled by detecting the word "headless"
->   and sending that as an argument to the browser specified
->   * **example:** "chrome_headless" converts to `:chrome`
->     with `headless` argument
+> **If the `BROWSER` environment variable is not provided (i.e. set),
+> then the default Watir (Chrome) browser is used**
+
+Mostly, this uses a _pass-through_ approach and should support any
+valid Watir browser.
 
 The following browsers were working on Mac at the time of this commit:
 * `chrome` - Google Chrome (requires Chrome)
-* `chrome_headless` - Google Chrome run in headless mode (requires Chrome > 59)
 * `edge` - Microsoft Edge (requires Edge)
-* `edge_headless` - Microsoft Edge run in headless mode (requires Edge)
 * `firefox` - Mozilla Firefox (requires Firefox)
-* `firefox_headless` - Mozilla Firefox run in headless mode (requires Firefox)
-* `safari` - Apple Safari (requires Safari)
+* `safari` - Apple Safari (local only, requires Safari)
 
 > This project uses the
 > [Webdrivers](https://github.com/titusfortner/webdrivers)
 > gem to automatically download and maintain chromedriver, edgedriver, and
-> geckodriver (Firefox).
+> geckodriver (Firefox)
+
+#### Specify Headless
+`HEADLESS=`...
+
+> **The `HEADLESS` environment variable is ignored if the `BROWSER`
+> environment variable is not provided (i.e. set)**
+
+**Example:**
+`HEADLESS=true`
+
+> The headless specification is implemented as _truthy_ (like Ruby)
+> and ignores case.  Setting `HEADLESS` to any value
+> including empty (i.e. `HEADLESS= `) is interpreted as `true`
+> except for the value `false`.  Thus, setting `HEADLESS=FALSE`
+> will **not** run headless.
 
 #### Specify Remote (Container) URL
 `REMOTE=`...
@@ -180,7 +192,7 @@ bundle exec cucumber
 
 #### Local Browsers
 ```
-BROWSER=chrome_headless bundle exec rake
+BROWSER=chrome HEADLESS=true bundle exec rake
 ```
 
 #### Using the Selenium Standalone Containers

--- a/docker-compose.selenium.yml
+++ b/docker-compose.selenium.yml
@@ -3,6 +3,7 @@ services:
   browsertests:
     environment:
       - BROWSER=${BROWSER:-chrome}
+      - HEADLESS=${HEADLESS-false}
       - REMOTE=http://${SELENIUM_HOSTNAME:-seleniumbrowser}:4444/wd/hub
       - REMOTE_STATUS=http://${SELENIUM_HOSTNAME:-seleniumbrowser}:4444/wd/hub/status
     command: ./script/runtests

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,49 +1,12 @@
 # frozen_string_literal: true
 
 require 'webdrivers'
+require_relative 'watir_browser'
 
 Before do
-  browser = ENV['BROWSER']
-  remote_url = ENV['REMOTE']
-  @browser = if remote_url
-               create_remote_browser(browser, remote_url)
-             else
-               create_local_browser browser
-             end
+  @browser = create_watir_browser
 end
 
 After do
   @browser.close
-end
-
-### Support ###
-def create_remote_browser(browser_info, remote_url)
-  browser = BrowserInfo.new browser_info
-  Watir::Browser.new browser.name, url: remote_url, headless: browser.headless
-end
-
-def create_local_browser(browser_info)
-  unless browser_info
-    warn '>> USING DEFAULT WATIR DRIVER <<'
-    return Watir::Browser.new
-  end
-  browser = BrowserInfo.new browser_info
-  # Not all watir browsers (Safari) support the headless option
-  if browser.headless
-    Watir::Browser.new browser.name, headless: browser.headless
-  else
-    Watir::Browser.new browser.name
-  end
-end
-
-# Parses out the browser name and attributes like headless
-class BrowserInfo
-  attr_reader :name, :headless
-
-  def initialize(browser_info)
-    browser_options = browser_info.downcase.strip.tr('_', ' ').split
-    @headless = !browser_options.delete('headless').nil?
-    # Assume whatever is left is the browser name (e.g. chrome)
-    @name = browser_options.first.to_sym
-  end
 end

--- a/features/support/watir_browser.rb
+++ b/features/support/watir_browser.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+def create_watir_browser
+  browser = ENV['BROWSER'].to_sym if ENV['BROWSER']
+  remote_url = ENV['REMOTE']
+  headless = headless? ENV['HEADLESS']
+
+  if remote_url
+    create_remote_browser(remote_url, browser, headless)
+  else
+    create_local_browser(browser, headless)
+  end
+end
+
+def create_remote_browser(remote_url, browser, headless)
+  Watir::Browser.new browser, url: remote_url, headless: headless
+end
+
+def create_local_browser(browser, headless)
+  # Use the default watir (Chrome) browser if no browser is specified
+  return Watir::Browser.new unless browser
+
+  # Not all watir browsers (Safari) support the headless option
+  if headless
+    Watir::Browser.new browser, headless: headless
+  else
+    Watir::Browser.new browser
+  end
+end
+
+def headless?(indicator)
+  return false if indicator.nil?
+
+  indicator.to_s.downcase != 'false'
+end


### PR DESCRIPTION
# What
This change set refactors the browser creation to support running headless using the `HEADLESS` environment variable instead of a `_headless` indicator in the `BROWSER` environment variable.

In addition, the browser creation logic was moved out of the `hooks` support file and into its own `watir_browser` file.

# Why
This change set simplifies the browser creation logic by having the headless specification in its own environment variable instead of combining with the browser specification.

# Change Impact Analysis and Testing
This change set impacts both local and remote browser creation.
- [x] Remote browser creation (CI)
  - [x] Chrome
  - [x] Firefox
  - [x] Edge
- [x] Local browser creation
  - [x] default
  - [x] Chrome
  - [x] Firefox
  - [x] Edge
  - [x] Safari

This change set adds ability to specify running headless for those browsers that support it.
- [x] Local
- [x] Remote
- [x] `HEADLESS=` - runs headless
  - [x] Local
  - [x] docker-compose
- [x] `HEADLESS=foo` - runs headless
- [x] `HEADLESS=true` - runs headless
- [x] `HEADLESS=fAlSe` - does NOT run headless

This change set updates the README.
- [x] Updates visually inspected