### PR TITLE
Some Cleanup

### DIFF
--- a/.github/workflows/check_development_environment.yml
+++ b/.github/workflows/check_development_environment.yml
@@ -46,7 +46,7 @@ jobs:
         run: "docker build --no-cache --target ${DEVENV} -t ${BROWSERTESTS_IMAGE} ."
 
       - name: dockercomposerun (Run tests) with defaults
-        run: BROWSERTESTS_SRC=${PWD} ./script/dockercomposerun
+        run: ./script/dockercomposerun
 
   runtests-specified-firefox:
     needs: build-devenv
@@ -61,7 +61,7 @@ jobs:
         run: "docker build --no-cache --target ${DEVENV} -t ${BROWSERTESTS_IMAGE} ."
 
       - name: dockercomposerun (Run tests) with Firefox
-        run: BROWSERTESTS_SRC=${PWD} ./script/dockercomposerun
+        run: ./script/dockercomposerun
 
   runtests-specified-edge:
     needs: build-devenv
@@ -76,4 +76,4 @@ jobs:
         run: "docker build --no-cache --target ${DEVENV} -t ${BROWSERTESTS_IMAGE} ."
 
       - name: dockercomposerun (Run tests) with Edge
-        run: BROWSERTESTS_SRC=${PWD} ./script/dockercomposerun
+        run: ./script/dockercomposerun

--- a/README.md
+++ b/README.md
@@ -244,6 +244,13 @@ To run the development environment in the docker-compose environment,
 with a Selenium Standalone container use the `dockercomposerun`
 script and run it interactively with the default shell `/bin/ash`...
 ```
+BROWSERTESTS_IMAGE=browsertests-dev ./script/dockercomposerun /bin/ash
+```
+
+To use another directory as the source code for the development
+environment, set the `BROWSERTESTS_SRC` environment variable.
+For example...
+```
 BROWSERTESTS_IMAGE=browsertests-dev BROWSERTESTS_SRC=${PWD} ./script/dockercomposerun /bin/ash
 ```
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,4 +3,4 @@ services:
   browsertests:
     image: "${BROWSERTESTS_IMAGE}"
     volumes:
-      - ${BROWSERTESTS_SRC}:/app
+      - ${BROWSERTESTS_SRC:-.}:/app

--- a/docker-compose.selenium.yml
+++ b/docker-compose.selenium.yml
@@ -3,7 +3,7 @@ services:
   browsertests:
     environment:
       - BROWSER=${BROWSER:-chrome}
-      - HEADLESS=${HEADLESS-false}
+      - HEADLESS
       - REMOTE=http://${SELENIUM_HOSTNAME:-seleniumbrowser}:4444/wd/hub
       - REMOTE_STATUS=http://${SELENIUM_HOSTNAME:-seleniumbrowser}:4444/wd/hub/status
     command: ./script/runtests

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'webdrivers'
 require_relative 'watir_browser'
 
 Before do

--- a/features/support/watir_browser.rb
+++ b/features/support/watir_browser.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'webdrivers'
+
 def create_watir_browser
   browser = ENV['BROWSER'].to_sym if ENV['BROWSER']
   remote_url = ENV['REMOTE']


### PR DESCRIPTION
# What
This change set does some cleanup and simple improvements, specifically...
  - Moves the Watir (browser) related dependencies out of the `spec_helper` and into the Watir browser support file
  - Changes the handling of the `HEADLESS` environment variable in `docker-compose.selenium.yml` to use the calling environment's `HEADLESS` environment variable instead of setting a default if not set - this makes the state of the `HEADLESS` environment variable exactly match the state in the calling environment (i.e. unset in the container if unset in the calling environment
  - Sets the current directory as the mounted source volume as the default in the development environment so that the user does not have to always specify it.

This change set follows the prior art of https://github.com/brianjbayer/sample-login-capybara-rspec/pull/50

# Why
Improve code quality, usability, and transparency. 

# Change Impact Analysis and Testing
  - Moving the Watir (browser) related dependencies impacts browser creation and was vetted by CI
  - Changing the `HEADLESS` environment variable was vetted manually using `dockercomposerun` and inspecting the state of the `HEADLESS` environment variable in the container and functionally using VNC.
  - Setting the  current directory as the mounted source volume as the default was vetted by CI
  - README updates were vetted by visually inspecting the rendered README on the branch
