### PR TITLE
Fix Issues with Source Code Handling in Deployment Image...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ USER deployer
 COPY --from=secscan --chown=deployer /usr/local/bundle/ /usr/local/bundle/
 # Copy in app source from the lint layer
 WORKDIR /app
-COPY --from=lint --chown=deployer . .
+COPY --from=lint --chown=deployer /app/ /app/
 
 # To Run the tests - altho this is orchestrated by the docker-compose.yml file
 #CMD bundle exec rake

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,6 @@ services:
   browsertests:
     build: .
     container_name: ${BROWSERTESTS_HOSTNAME:-browsertests}
-    volumes:
-      - .:/app
     environment:
       - LOGIN_USERNAME
       - LOGIN_PASSWORD


### PR DESCRIPTION
# What
This change set is a fix for a bug (overriding the image copy of the source code with volume mounting the host current directory) masking another bug (copying in `/` in the `/app` WORKDIR directory so `/app/app` is where the source is).

Based upon prior art https://github.com/brianjbayer/sample-login-capybara-rspec/pull/52

# Why
  - Deploy image source code will now be used and immutable in Docker Compose framework
  - Deploy image source will be copied into the right location (/app) and `/` will not be copied into `/app`

# Change Impact Analysis and Testing
- [x] Changes based upon prior art
- [x] Verified by shelling into deployment container and exploratory testing to ensure immutable and proper pathing