### PR TITLE
Move Lint and Static Security Scanning Out of Dockerfile to CI

### DIFF
--- a/.github/workflows/check_deployable.yml
+++ b/.github/workflows/check_deployable.yml
@@ -15,25 +15,37 @@ jobs:
 
   code-standards-rubocop:
     runs-on: ubuntu-latest
+    env:
+      DEVENV: devenv
+      BROWSERTESTS_IMAGE: app-devenv
 
     steps:
       - uses: actions/checkout@v1
       - name: Docker version
         run: docker --version
 
-      - name: Build linted app code deploy
-        run: docker build --no-cache --target lint -t app-lint .
+      - name: Build app development environment
+        run: "docker build --no-cache --target ${DEVENV} -t ${BROWSERTESTS_IMAGE} ."
+
+      - name: Run the linting in the dev image
+        run: ./script/dockercomposerun -d -n ./script/runlint
 
   security-scan-bundler-audit:
     runs-on: ubuntu-latest
+    env:
+      DEVENV: devenv
+      BROWSERTESTS_IMAGE: app-devenv
 
     steps:
       - uses: actions/checkout@v1
       - name: Docker version
         run: docker --version
 
-      - name: Build security-scanned app code for deploy
-        run: docker build --no-cache --target secscan -t app-secscan .
+      - name: Build app development environment
+        run: "docker build --no-cache --target ${DEVENV} -t ${BROWSERTESTS_IMAGE} ."
+
+      - name: Run the linting in the dev image
+        run: ./script/dockercomposerun -d -n ./script/runsecscan
 
   build-deploy:
     needs: [code-standards-rubocop, security-scan-bundler-audit]

--- a/.github/workflows/check_development_environment.yml
+++ b/.github/workflows/check_development_environment.yml
@@ -49,7 +49,7 @@ jobs:
         run: "docker build --no-cache --target ${DEVENV} -t ${BROWSERTESTS_IMAGE} ."
 
       - name: dockercomposerun (Run tests) with defaults
-        run: ./script/dockercomposerun
+        run: ./script/dockercomposerun -d
 
   runtests-specified-firefox:
     needs: build-devenv
@@ -66,7 +66,7 @@ jobs:
         run: "docker build --no-cache --target ${DEVENV} -t ${BROWSERTESTS_IMAGE} ."
 
       - name: dockercomposerun (Run tests) with Firefox
-        run: ./script/dockercomposerun
+        run: ./script/dockercomposerun -d
 
   runtests-specified-edge:
     needs: build-devenv
@@ -83,4 +83,4 @@ jobs:
         run: "docker build --no-cache --target ${DEVENV} -t ${BROWSERTESTS_IMAGE} ."
 
       - name: dockercomposerun (Run tests) with Edge
-        run: ./script/dockercomposerun
+        run: ./script/dockercomposerun -d

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ FROM builder AS secscan
 RUN apk add --no-cache git
 # Just need Rakefile and Gemfile.lock
 COPY Rakefile ./
-RUN bundle exec rake bundle:audit
+RUN bundle exec bundle-audit check --update
 
 ### Deploy Stage ###
 FROM ruby-alpine AS deploy

--- a/README.md
+++ b/README.md
@@ -252,34 +252,35 @@ To develop using the supplied container-based development environment...
    ```
    docker build --no-cache --target devenv -t browsertests-dev .
    ```
-2. Run the development environment image either on its own or
-   in the docker-compose environment with either the Selenium Chrome
-   or Firefox container.  By default the development environment
+2. Run the development environment image in the docker-compose environment
+   either alone or with the Selenium Chrome (or Selenium browser
+   containers)  By default the development environment
    container executes the `/bin/ash` shell providing a command
    line interface. When running the development environment
    container, you must specify the path to this project's
    source code.
 
 #### Running Just the Test Development Image
-To run the development environment on its own, use
-`docker run`...
+To run the development environment in the docker-compose environment alone
+without a Selenium Standalone container use `-n` to specify no browser and
+`-d` to specify the development environment with `dockercomposerun`...
 ```
-docker run -it --rm -v $(pwd):/app browsertests-dev
+BROWSERTESTS_IMAGE=browsertests-dev LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun -n -d sh
 ```
 
-#### Running the Test Development Image in docker-compose
-To run the development environment in the docker-compose environment,
+#### Running the Test Development Image with the Selenium Browser
+To run the development environment in the docker-compose environment
 with a Selenium Standalone container use the `dockercomposerun`
 script and run it interactively with the default shell `/bin/ash`...
 ```
-BROWSERTESTS_IMAGE=browsertests-dev LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun /bin/ash
+BROWSERTESTS_IMAGE=browsertests-dev LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun -d sh
 ```
 
 To use another directory as the source code for the development
 environment, set the `BROWSERTESTS_SRC` environment variable.
 For example...
 ```
-BROWSERTESTS_SRC=${PWD} BROWSERTESTS_IMAGE=browsertests-dev LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun /bin/ash
+BROWSERTESTS_SRC=${PWD} BROWSERTESTS_IMAGE=browsertests-dev LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun -d sh
 ```
 
 ## Sources and Additional Information

--- a/script/dockercomposerun
+++ b/script/dockercomposerun
@@ -6,11 +6,44 @@
 #
 # - Any environment variables set when calling this script are passed
 #   through to the docker-compose framework
-#   (e.g. configuration other than the defaults
-#
+#   (e.g. configuration other than the defaults)
+# OPTIONS:
+# -d: Use the docker-compose Dev environment with BROWSERTESTS_IMAGE
+# -n: No Selenium browser in the docker-compose environment
+# ----------------------------------------------------------------------
+
+usage() {
+  echo "Usage: $0 [-dn] [CMD]"
+}
+
+err_exit() {
+  local err_msg="$1"
+  local err_code=$2
+  echo "${err_msg}  --  Exit:[${err_code}]" 1>&2
+  usage
+  exit $err_code
+}
 
 # Exit script on any errors
 set -e
+
+# Handle options
+while getopts ":cdn" options; do
+  case "${options}" in
+    d)
+      echo "Development Environment"
+      devenv=true
+      ;;
+    n)
+      echo "No Selenium"
+      noselenium=true
+      ;;
+    \?)
+    err_exit "Invalid Option: -$OPTARG" 1
+      ;;
+  esac
+done
+shift $((OPTIND-1))
 
 echo ''
 echo "ENVIRONMENT VARIABLES..."
@@ -22,9 +55,17 @@ docker --version
 docker-compose --version
 echo ''
 
+# Override docker compose environments
 echo 'DOCKER-COMPOSE COMMAND...'
-docker_compose_command='docker-compose -f docker-compose.yml -f docker-compose.selenium.yml '
-if [ ! -z ${BROWSERTESTS_IMAGE} ]; then
+docker_compose_command='docker-compose -f docker-compose.yml '
+
+# Unless the no selenium option is set, use Selenium browser
+if [ -z ${noselenium} ]; then
+  echo "...Adding Selenium Browser to Environment"
+  docker_compose_command="${docker_compose_command} -f docker-compose.selenium.yml "
+fi
+
+if [ ! -z ${devenv} ]; then
   echo "...Using Development Environment with Image [${BROWSERTESTS_IMAGE}]"
   docker_compose_command="${docker_compose_command} -f docker-compose.dev.yml "
 fi

--- a/script/runlint
+++ b/script/runlint
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Exit script on any errors
+set -e
+
+# Run RuboCop in the bundle environment for linting
+# and pass through any arguments
+run_command="bundle exec rubocop $@"
+
+# Generic run command and catch error
+echo "RUNNING [${run_command} ]..."
+# Allow to fail but catch return code
+set +e
+$run_command
+run_return_code=$?
+# NOTE return code must be caught before any other command
+set -e
+echo ''
+
+echo "EXITING WITH RUN RETURN CODE [${run_return_code}]"
+exit $run_return_code

--- a/script/runsecscan
+++ b/script/runsecscan
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# Exit script on any errors
+set -e
+
+# Run bundler-audit in the bundle environment for
+# security scan of dependencies and pass through
+# any arguments
+run_command="bundle exec bundle-audit check --update $@"
+
+# Generic run command and catch error
+echo "RUNNING [${run_command}]..."
+# Allow to fail but catch return code
+set +e
+$run_command
+run_return_code=$?
+# NOTE return code must be caught before any other command
+set -e
+echo ''
+
+echo "EXITING WITH RUN RETURN CODE [${run_return_code}]"
+exit $run_return_code


### PR DESCRIPTION
# What
This moves the CI actions of linting and static security scanning out of the `Dockerfile` and into the actual CI of GitHub Actions.  This is based upon prior art https://github.com/brianjbayer/sample-login-capybara-rspec/pull/55.

As part of this effort, the `dockercomposerun` script was refactored to use command line options to specify the development environment and No-Selenium-browser option.

# Why
Doing CI in the `Dockerfile` is an anti-pattern of doing too much.  This is also in preparation for moving to true image-based CI/CD.

# Change Impact Analysis and Testing
Vetted manually and with CI checks.
