### PR TITLE
Normalize Branch-Based Image Name in CI/CD 

### DIFF
--- a/.github/workflows/on_pr_build_push_vet_images.yml
+++ b/.github/workflows/on_pr_build_push_vet_images.yml
@@ -5,61 +5,68 @@ on:
     branches:
       - main
 
-env:
-  BRANCH: ${{ github.head_ref }}
-  COMMIT: ${{ github.event.pull_request.head.sha }}
+# FYI...
+#  Raw Branch Name: ${{ github.head_ref }}
+#  <commit-sha>: ${{ github.event.pull_request.head.sha }}
 
-# Possibly produced images
-  #             owner/repository_branch:commitsha
-  VETTED_IMAGE: ${{ github.repository }}_${{ github.head_ref }}:${{ github.event.pull_request.head.sha }}
-
-  #               owner/repository_branch_unvetted:commitsha
-  UNVETTED_IMAGE: ${{ github.repository }}_${{ github.head_ref }}_unvetted:${{ github.event.pull_request.head.sha }}
-
-  #             owner/repository_branch_dev:commitsha
-  DEVENV_IMAGE: ${{ github.repository }}_${{ github.head_ref }}_dev:${{ github.event.pull_request.head.sha }}
+# Produced images...
+#  1. (Always) Unvetted Image: <owner/repository>_<normalized-branch>_unvetted:<commit-sha>
+#  2. (Always) Dev Environment Image: <owner/repository>_<normalized-branch>_dev:<commit-sha>
+#  3. (If vetted) Vetted_image: <owner/repository>_<normalized-branch>:<commit-sha>
 
 jobs:
+  # Normalize the branch for image name
+  pr-norm-branch:
+    uses: brianjbayer/actions-image-cicd/.github/workflows/normalize_for_image_name.yml@main
+    with:
+      raw_name: ${{ github.head_ref }}
 
   # Build and Push Images
   build-and-push-branch-devenv:
+    needs: [pr-norm-branch]
     uses: brianjbayer/actions-image-cicd/.github/workflows/build_push_image.yml@main
     with:
-      image: ${{ github.repository }}_${{ github.head_ref }}_dev:${{ github.event.pull_request.head.sha }}
+      image: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
       buildopts: --target devenv
     secrets:
       registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
   build-and-push-branch-unvetted:
+    needs: [pr-norm-branch]
     uses: brianjbayer/actions-image-cicd/.github/workflows/build_push_image.yml@main
     with:
-      image: ${{ github.repository }}_${{ github.head_ref }}_unvetted:${{ github.event.pull_request.head.sha }}
+      image: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_unvetted:${{ github.event.pull_request.head.sha }}
     secrets:
       registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
   # Vet Deploy Image
   vet-code-standards:
-    needs: build-and-push-branch-devenv
+    needs: [pr-norm-branch, build-and-push-branch-devenv]
     runs-on: ubuntu-latest
+    env:
+      DEVENV_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
     steps:
       - uses: actions/checkout@v1
       - name: dockercomposerun rubocop on development environment
         run: "BROWSERTESTS_IMAGE=${DEVENV_IMAGE} ./script/dockercomposerun -n -d ./script/runlint"
 
   vet-dependency-security:
-    needs: build-and-push-branch-devenv
+    needs: [pr-norm-branch, build-and-push-branch-devenv]
     runs-on: ubuntu-latest
+    env:
+      DEVENV_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
     steps:
       - uses: actions/checkout@v1
       - name: dockercomposerun bundle-audit on development environment
         run: "BROWSERTESTS_IMAGE=${DEVENV_IMAGE} ./script/dockercomposerun -n -d ./script/runsecscan"
 
   vet-e2e-tests-deploy-image-default-chrome:
-    needs: build-and-push-branch-unvetted
+    needs: [pr-norm-branch, build-and-push-branch-unvetted]
     runs-on: ubuntu-latest
     env:
+      UNVETTED_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_unvetted:${{ github.event.pull_request.head.sha }}
       LOGIN_USERNAME: ${{ secrets.LOGIN_USERNAME }}
       LOGIN_PASSWORD: ${{ secrets.LOGIN_PASSWORD }}
     steps:
@@ -68,9 +75,10 @@ jobs:
         run: "BROWSERTESTS_IMAGE=${UNVETTED_IMAGE} ./script/dockercomposerun -c"
 
   vet-e2e-tests-deploy-image-firefox:
-    needs: build-and-push-branch-unvetted
+    needs: [pr-norm-branch, build-and-push-branch-unvetted]
     runs-on: ubuntu-latest
     env:
+      UNVETTED_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_unvetted:${{ github.event.pull_request.head.sha }}
       BROWSER: firefox
       SELENIUM_IMAGE: selenium/standalone-firefox:latest
       LOGIN_USERNAME: ${{ secrets.LOGIN_USERNAME }}
@@ -81,9 +89,10 @@ jobs:
         run: "BROWSERTESTS_IMAGE=${UNVETTED_IMAGE} ./script/dockercomposerun -c"
 
   vet-e2e-tests-deploy-image-edge:
-    needs: build-and-push-branch-unvetted
+    needs: [pr-norm-branch, build-and-push-branch-unvetted]
     runs-on: ubuntu-latest
     env:
+      UNVETTED_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_unvetted:${{ github.event.pull_request.head.sha }}
       BROWSER: edge
       SELENIUM_IMAGE: selenium/standalone-edge:latest
       LOGIN_USERNAME: ${{ secrets.LOGIN_USERNAME }}
@@ -101,21 +110,23 @@ jobs:
       - vet-e2e-tests-deploy-image-default-chrome
       - vet-e2e-tests-deploy-image-firefox
       - vet-e2e-tests-deploy-image-edge
+      - pr-norm-branch
     uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_image.yml@main
     with:
       # Pull unvetted branch image
-      pull_as: ${{ github.repository }}_${{ github.head_ref }}_unvetted:${{ github.event.pull_request.head.sha }}
+      pull_as: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_unvetted:${{ github.event.pull_request.head.sha }}
       # Push Vetted Image
-      push_as: ${{ github.repository }}_${{ github.head_ref }}:${{ github.event.pull_request.head.sha }}
+      push_as: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}:${{ github.event.pull_request.head.sha }}
     secrets:
       registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
   # Vet Dev Environment Image
   vet-e2e-tests-devenv-image-default-chrome:
-    needs: build-and-push-branch-devenv
+    needs: [pr-norm-branch, build-and-push-branch-devenv]
     runs-on: ubuntu-latest
     env:
+      DEVENV_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
       LOGIN_USERNAME: ${{ secrets.LOGIN_USERNAME }}
       LOGIN_PASSWORD: ${{ secrets.LOGIN_PASSWORD }}
     steps:
@@ -124,9 +135,10 @@ jobs:
         run: "BROWSERTESTS_IMAGE=${DEVENV_IMAGE} ./script/dockercomposerun -d ./script/runtests"
 
   vet-e2e-tests-devenv-image-firefox:
-    needs: build-and-push-branch-devenv
+    needs: [pr-norm-branch, build-and-push-branch-devenv]
     runs-on: ubuntu-latest
     env:
+      DEVENV_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
       BROWSER: firefox
       SELENIUM_IMAGE: selenium/standalone-firefox:latest
       LOGIN_USERNAME: ${{ secrets.LOGIN_USERNAME }}
@@ -137,9 +149,10 @@ jobs:
         run: "BROWSERTESTS_IMAGE=${DEVENV_IMAGE} ./script/dockercomposerun -d ./script/runtests"
 
   vet-e2e-tests-devenv-image-edge:
-    needs: build-and-push-branch-devenv
+    needs: [pr-norm-branch, build-and-push-branch-devenv]
     runs-on: ubuntu-latest
     env:
+      DEVENV_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
       BROWSER: edge
       SELENIUM_IMAGE: selenium/standalone-edge:latest
       LOGIN_USERNAME: ${{ secrets.LOGIN_USERNAME }}

--- a/.github/workflows/on_push_to_main_promote_to_prod.yml
+++ b/.github/workflows/on_push_to_main_promote_to_prod.yml
@@ -5,28 +5,37 @@ on:
       - main
 
 jobs:
-
   branch-and-last-commit:
     uses: brianjbayer/actions-image-cicd/.github/workflows/get_merged_branch_last_commit.yml@main
 
-  branch-and-last-commit-merged-info:
+  push-norm-branch:
     needs: [branch-and-last-commit]
+    uses: brianjbayer/actions-image-cicd/.github/workflows/normalize_for_image_name.yml@main
+    with:
+      raw_name: ${{ needs.branch-and-last-commit.outputs.branch }}
+
+  branch-and-last-commit-merged-info:
+    needs: [branch-and-last-commit, push-norm-branch]
     runs-on: ubuntu-latest
     env:
       BRANCH_LAST_COMMIT: ${{ needs.branch-and-last-commit.outputs.commit }}
       BRANCH: ${{ needs.branch-and-last-commit.outputs.branch }}
+      NORM_BRANCH: ${{ needs.push-norm-branch.outputs.name }}
+
     steps:
       - name: Output last commit of merged branch env var
         run: echo "BRANCH_LAST_COMMIT=[${BRANCH_LAST_COMMIT}]"
       - name: Output merged branch env var
         run: echo "BRANCH=[${BRANCH}]"
+      - name: Output normalized merged branch env var
+        run: echo "NORM_BRANCH=[${NORM_BRANCH}]"
 
   promote-branch-last-commit-to-prod:
-    needs: [branch-and-last-commit]
+    needs: [branch-and-last-commit, push-norm-branch]
     uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_image.yml@main
     with:
       # Pull last (vetted) branch image
-      pull_as: ${{ github.repository }}_${{ needs.branch-and-last-commit.outputs.branch }}:${{ needs.branch-and-last-commit.outputs.commit }}
+      pull_as: ${{ github.repository }}_${{ needs.push-norm-branch.outputs.name }}:${{ needs.branch-and-last-commit.outputs.commit }}
       # Push prod Image
       push_as: ${{ github.repository }}:${{ needs.branch-and-last-commit.outputs.commit }}
     secrets:
@@ -44,11 +53,11 @@ jobs:
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
   promote-branch-last-commit-devenv:
-    needs: [branch-and-last-commit]
+    needs: [branch-and-last-commit, push-norm-branch]
     uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_image.yml@main
     with:
       # Pull last branch devenv image
-      pull_as: ${{ github.repository }}_${{ needs.branch-and-last-commit.outputs.branch }}_dev:${{ needs.branch-and-last-commit.outputs.commit }}
+      pull_as: ${{ github.repository }}_${{ needs.push-norm-branch.outputs.name }}_dev:${{ needs.branch-and-last-commit.outputs.commit }}
       # Push prod devenv image
       push_as: ${{ github.repository }}-dev:${{ needs.branch-and-last-commit.outputs.commit }}
     secrets:


### PR DESCRIPTION
# What & Why
This changeset adds normalization of the branch name to the image-based CI/CD.  This allows for branch names (like dependabot-generated ones) that do not follow Docker image naming requirements.

> This PR is completely based upon the prior art https://github.com/brianjbayer/sample-login-capybara-rspec/pull/62.
> Changed files were directly copied from the prior art. 

# Change Impact Analysis and Testing
The on-PR workflow changes are vetted by the on-PR checks themselves as well as manual inspection of the Docker Hub container registry.  However, the onPush/Merge workflow changes which are vetted by that workflow only run at merge.
