### PR TITLE
Parameterize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,23 @@
-# sample-login-watir-cucumber
+#-----------------------------------
+#--- sample-login-watir-cucumber ---
+#-----------------------------------
+
 ### Base Image ###
-FROM ruby:2.7.7-alpine AS ruby-alpine
+ARG BASE_IMAGE=ruby:2.7.7-alpine
+FROM ${BASE_IMAGE} AS ruby-alpine
 
 ### Builder Stage ###
 FROM ruby-alpine AS builder
+
 # Need to add lib-ffi to build ffi gem native extensions
-RUN apk --update add --virtual build-dependencies build-base libffi-dev
+ARG BUILD_PACKAGES='build-dependencies build-base libffi-dev'
 
 # Use the same version of Bundler in the Gemfile.lock
-RUN gem install bundler:2.3.26
+ARG BUNDLER_VER=2.3.26
+
+RUN apk --update add --virtual ${BUILD_PACKAGES} \
+  && gem install bundler:${BUNDLER_VER}
+
 WORKDIR /app
 # Install the Ruby dependencies (defined in the Gemfile/Gemfile.lock)
 COPY Gemfile Gemfile.lock ./
@@ -18,22 +27,28 @@ RUN bundle install
 # Before any checks stages so that we can always build a dev env
 # ASSUME source is docker volumed into the image
 FROM builder AS devenv
-# Add git and vim at least
-RUN apk add --no-cache git
-RUN apk add --no-cache vim
+
+# For Dev Env, add git and vim at least
+ARG DEVENV_PACKAGES='git vim'
+
+RUN apk --update add ${DEVENV_PACKAGES}
+
 # Start devenv in (command line) shell
 CMD sh
 
 ### Deploy Stage ###
 FROM ruby-alpine AS deploy
-# Throw errors if Gemfile has been modified since Gemfile.lock
-RUN bundle config --global frozen 1
 
-RUN adduser -D deployer
+# Throw errors if Gemfile has been modified since Gemfile.lock
+RUN bundle config --global frozen 1 \
+  # Add a user so not running as root
+  && adduser -D deployer
+
 USER deployer
 
-# Copy over the built gems directory from the scanned layer
+# Copy over the built gems (directory)
 COPY --from=builder --chown=deployer /usr/local/bundle/ /usr/local/bundle/
+
 # Copy source to /app
 WORKDIR /app
 COPY --chown=deployer . /app/


### PR DESCRIPTION
# What
This non-functional changeset adds some parameterization with default values to the project `Dockerfile`, specifically...
  - Base image (e.g. `--build-arg BASE_IMAGE=...`)
  - Bundler version (e.g. `--build-arg BUNDLER_VER=...`)
  - Build packages to install (e.g.  `--build-arg BUILD_PACKAGES=...`)
  - Dev environment packages to install (e.g.  `--build-arg DEVENV_PACKAGES=...`)

# Why
This should make development more flexible, adding the ability to override these values without having to modify the `Dockerfile`.  It also hopefully makes the specific values more readable and apparent.

# Change Impact Analysis and Testing
This changeset impacts the building and proper operation of the image.

- [x] CI tests building and operating both the deploy and dev environment images
- [x] Manually tested overriding the Base Image and Bundler version (`docker build --build-arg BASE_IMAGE=ruby:2.7.6-alpine --build-arg BUNDLER_VER=2.3.25 --no-cache --target devenv -t browsertests-dev .`)
