### PR TITLE
Address Selenium [DEPRECATION] [:headless] Warnings for Firefox

### DIFF
--- a/features/support/watir_browser.rb
+++ b/features/support/watir_browser.rb
@@ -5,29 +5,29 @@ require 'webdrivers'
 def create_watir_browser
   browser = specified_browser
   remote_url = specified_remote_url
-  headless = headless_specified?
 
   if remote_url
-    create_remote_browser(remote_url, browser, headless)
+    create_remote_browser(remote_url, browser)
   else
-    create_local_browser(browser, headless)
+    create_local_browser(browser)
   end
 end
 
-def create_remote_browser(remote_url, browser, headless)
-  Watir::Browser.new browser, url: remote_url, headless:
+def create_remote_browser(remote_url, browser)
+  Watir::Browser.new browser, url: remote_url, options: browser_options
 end
 
-def create_local_browser(browser, headless)
+def create_local_browser(browser)
   # Use the default watir (Chrome) browser if no browser is specified
   return Watir::Browser.new unless browser
 
-  # Not all watir browsers (Safari) support the headless option
-  if headless
-    Watir::Browser.new(browser, headless:)
-  else
-    Watir::Browser.new browser
-  end
+  Watir::Browser.new(browser, options: browser_options)
+end
+
+def browser_options
+  options = {}
+  options[:args] = ['--headless'] if headless_specified?
+  options
 end
 
 def specified_browser


### PR DESCRIPTION
# What
This changeset makes no changes to existing behavior, but resolves the the following [Selenium Webdriver](https://github.com/SeleniumHQ/selenium) deprecations warning for Firefox...
```
WARN Selenium [DEPRECATION] [:headless] `Options#headless!` is deprecated. Use `Options#add_argument('-headless')` instead.
```

# Why
Selenium (and Watir) has changed the way that it handles specifying headless.  This change only resulted in the deprecation warning for Firefox.  Although, this is only a warning now, this approach will be deprecated in the future, so the changes to address this in this project were made now.

# Change Impact Analysis and Testing
These changes are related to the Watir browser creation and effect all browser creations both local and remote as well as headless.

- [x] Remote non-headless supported browsers are vetted for no regressions by CI
- [x] Local headless and non-headless supported browsers (on Mac) are vetted by manual testing of all browsers with and without headless (if supported)
- [x] Remote headless supported browsers are vetted by manual testing of both a Chromium-based browser and Firefox

