### PR TITLE
Deprecate the webdrivers Gem for the Selenium Manager facility in selenium-webdrivers Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,3 @@ gem 'rubocop', require: false
 gem 'rubocop-rake', require: false
 gem 'rubocop-rspec', require: false
 gem 'selenium-webdriver'
-gem 'webdrivers', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,8 +47,6 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2023.0218.1)
     multi_test (1.1.0)
-    nokogiri (1.15.3-x86_64-linux)
-      racc (~> 1.4)
     page-object (2.3.1)
       page_navigation (>= 0.10)
       watir (>= 6.10.3)
@@ -72,11 +70,11 @@ GEM
     rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.5)
+    rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.1)
-    rubocop (1.54.1)
+    rubocop (1.55.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -84,7 +82,7 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.28.0, < 2.0)
+      rubocop-ast (>= 1.28.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.29.0)
@@ -112,10 +110,6 @@ GEM
     watir (7.2.2)
       regexp_parser (>= 1.2, < 3)
       selenium-webdriver (~> 4.2)
-    webdrivers (4.7.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (> 3.141, < 5.0)
     websocket (1.2.9)
     yml_reader (0.7)
 
@@ -133,7 +127,6 @@ DEPENDENCIES
   rubocop-rake
   rubocop-rspec
   selenium-webdriver
-  webdrivers (~> 4.0)
 
 BUNDLED WITH
    2.4.15

--- a/README.md
+++ b/README.md
@@ -138,7 +138,6 @@ For more information, see [DEVELOPMENT.md](docs/DEVELOPMENT.md).
 
 ## Sources and Additional Information
 * The [Page-Object gem](https://rubygems.org/gems/page-object)
-* The [Webdrivers gem](https://github.com/titusfortner/webdrivers)
 * The [Selenium Docker Images](https://github.com/SeleniumHQ/docker-selenium)
 * The [Rubocop style enforcer and linter](https://rubocop.org/)
 * The [bundler-audit dependency static security scanner](https://github.com/rubysec/bundler-audit)

--- a/docs/RUNNING_NATIVELY.md
+++ b/docs/RUNNING_NATIVELY.md
@@ -48,9 +48,10 @@ The following browsers were working on Mac at the time of this commit:
 * `safari` - Apple Safari (local only, requires Safari)
 
 > This project uses the
-> [Webdrivers](https://github.com/titusfortner/webdrivers)
-> gem to automatically download and maintain chromedriver, edgedriver, and
-> geckodriver (Firefox)
+> [Selenium Manager](https://www.selenium.dev/blog/2022/introducing-selenium-manager/)
+> facility built into the `selenium-webdriver` gem to automatically
+> download and maintain chromedriver, edgedriver,
+> and geckodriver (Firefox).
 
 #### Specify Headless
 `HEADLESS=`...

--- a/features/support/watir_browser.rb
+++ b/features/support/watir_browser.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'webdrivers'
-
 def create_watir_browser
   browser = specified_browser
   remote_url = specified_remote_url


### PR DESCRIPTION
# What

> This changeset follows prior art https://github.com/brianjbayer/sample-login-capybara-rspec/pull/88

This changeset deprecates the use of the [`webdrivers`](https://github.com/titusfortner/webdrivers) gem for native browser driver (e.g. chromedriver, geckodriver, edgedriver) installation and management.  This browser driver installation and management is now built into the `selenium-webdriver` gem which is already being used by this project.

This changeset also updates any gems.

> 👀 For more information see the new [Selenium Manager](https://www.selenium.dev/blog/2022/introducing-selenium-manager/). 

# Why
With browser driver management now built into `selenium-webdriver`, the `webdrivers` gem is not as actively maintained.

# Change Impact Analysis and Testing

- [x] CI checks code standards and no regressions in behavior
- [x] Manually ran supported browsers natively (Chrome 115)