### PR TITLE
Add Global Configuration and a BASE_URL Environment Variable for the Test Pages

### DIFF
--- a/.github/workflows/on_pr_build_push_vet_images.yml
+++ b/.github/workflows/on_pr_build_push_vet_images.yml
@@ -73,6 +73,7 @@ jobs:
       UNVETTED_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_unvetted:${{ github.event.pull_request.head.sha }}
       BROWSER: ${{ matrix.browser }}
       SELENIUM_IMAGE: selenium/standalone-${{ matrix.browser }}:latest
+      BASE_URL: "https://the-internet.herokuapp.com"
       LOGIN_USERNAME: ${{ secrets.LOGIN_USERNAME }}
       LOGIN_PASSWORD: ${{ secrets.LOGIN_PASSWORD }}
     steps:
@@ -109,6 +110,7 @@ jobs:
       DEVENV_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
       BROWSER: ${{ matrix.browser }}
       SELENIUM_IMAGE: selenium/standalone-${{ matrix.browser }}:latest
+      BASE_URL: "https://the-internet.herokuapp.com"
       LOGIN_USERNAME: ${{ secrets.LOGIN_USERNAME }}
       LOGIN_PASSWORD: ${{ secrets.LOGIN_PASSWORD }}
     steps:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ This framework contains support for...
 * Basic secrets management using environment variables and
   [GitHub Secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
 
+## Prerequisites
+
+Before being able to run this project, you must follow the requirements
+in the [PREREQUISITES.md](docs/PREREQUISITES.md)
+
 ## Running
 The easiest way to run the tests is with the docker compose
 framework using the `dockercomposerun` script.
@@ -50,34 +55,7 @@ container.
 You can view the running tests using the included
 Virtual Network Computing (VNC) server.
 
-### Prerequisites
-1. You must have Docker installed and running on your local machine.
-2. You must specify the login credentials (i.e. secrets) used in the
-   test with the `LOGIN_USERNAME` and `LOGIN_PASSWORD` environment
-   variables...
-   ```
-   LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword!
-   ```
 
-### Running Using the Default Chrome Standalone Container
-By default, the `dockercomposerun` script runs using the latest
-Selenium Standalone Chrome container.
-1. Ensure Docker is running
-2. From the project root directory, run the `dockercomposerun`
-   script with the defaults...
-   ```
-   LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun
-   ```
-
-### Optional: Creating a `.env` File
-You can create a file named `.env` in the project root directory
-that contains the required environment variables that will
-be used by default by Docker Compose instead of setting them on
-the command line...
-```
-LOGIN_USERNAME=tomsmith
-LOGIN_PASSWORD=SuperSecretPassword!
-```
 
 ### Seeing the Tests Run
 > Browsers in the containers are not visible in the VNC server
@@ -100,6 +78,16 @@ You can use either a VNC client or a web browser to view the tests.
 For more information, see the Selenium Standalone Image
 [VNC documentation](https://github.com/SeleniumHQ/docker-selenium#debugging)
 
+### Running Using the Default Chrome Standalone Container
+By default, the `dockercomposerun` script runs using the latest
+Selenium Standalone Chrome container.
+1. Ensure Docker is running
+2. From the project root directory, run the `dockercomposerun`
+   script with the defaults...
+   ```
+   ./script/dockercomposerun
+   ```
+
 ### Running Using Other Selenium Standalone Containers
 You can also run the tests using other Selenium Standalone
 containers (such as Firefox and Edge) with the docker compose
@@ -114,7 +102,7 @@ You can run the tests interactively by "shelling in" to the test container.
 2. From the project root directory, run the `dockercomposerun`
    script and supply the shell command `sh`...
    ```
-   LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun sh
+   ./script/dockercomposerun sh
    ```
 3. Run desired commands in the container
    (e.g. `bundle exec rake`)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,5 +4,6 @@ services:
     image: brianjbayer/sample-login-watir-cucumber:${BROWSERTESTS_TAG:-latest}
     container_name: ${BROWSERTESTS_HOSTNAME:-browsertests}
     environment:
+      - BASE_URL
       - LOGIN_USERNAME
       - LOGIN_PASSWORD

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -8,12 +8,16 @@ code to recognize and persist any changes.
 By default the development environment container executes the alpine
 `/bin/ash` shell providing a command line interface.
 
+### Prerequisites
+Before being able to run this project, you must follow the requirements
+in the [PREREQUISITES.md](PREREQUISITES.md)
+
 ### To Develop Using the Container-Based Development Environment
 The easiest way to run the containerized development environment is with
 the docker-compose framework using the `dockercomposerun` script with the
 `-d` (development environment) option...
 ```
-LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun -d
+./script/dockercomposerun -d
 ```
 
 This will pull and run the latest development environment image of this
@@ -25,7 +29,7 @@ To run the development environment on its own in the docker-compose
 environment **without a Selenium browser**, use the `-n` option for
 no Selenium and the `-d` option for the development environment...
 ```
-LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun -n -d
+./script/dockercomposerun -n -d
 ```
 
 #### Building Your Own Development Environment Image
@@ -42,7 +46,7 @@ You can also build and run your own development environment image.
    (or other browser containers) and specify your development
    environment image with `BROWSERTESTS_IMAGE`
    ```
-   BROWSERTESTS_IMAGE=browsertests-dev LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun -n -d
+   BROWSERTESTS_IMAGE=browsertests-dev ./script/dockercomposerun -n -d
    ```
 
 #### Specifying the Source Code Location
@@ -50,7 +54,7 @@ To use another directory as the source code for the development
 environment, set the `BROWSERTESTS_SRC` environment variable.
 For example...
 ```
-BROWSERTESTS_SRC=${PWD} BROWSERTESTS_IMAGE=browsertests-dev LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun -d
+BROWSERTESTS_SRC=${PWD} BROWSERTESTS_IMAGE=browsertests-dev ./script/dockercomposerun -d
 ```
 
 #### Running the Tests, Linting, and Security Scanning

--- a/docs/PREREQUISITES.md
+++ b/docs/PREREQUISITES.md
@@ -1,0 +1,41 @@
+## Prerequisites
+
+In order to run this project...
+
+1. You must have Docker installed and running on your host
+   machine to run the project using the docker compose framework
+
+2. To run the tests, you must set the required environment
+   variable and value...
+   ```
+   BASE_URL='https://the-internet.herokuapp.com'
+   ```
+
+3. To run the tests, you must set the required secret
+   environment variable and value...
+   ```
+   LOGIN_USERNAME=tomsmith
+   ```
+
+4. To run the tests, you must set the required secret
+   environment variable and value...
+   ```
+   LOGIN_PASSWORD=SuperSecretPassword!
+   ```
+
+> These are publicly available values but demonstrate
+> basic secret management
+
+### Optional: Creating a `.env` File
+You can create a file named `.env` in the project root directory
+that contains the required environment variables that will
+be used by default by docker compose instead of setting them on
+the command line...
+
+> :no_entry_sign: However your `.env` file will not be used when running natively
+
+```
+BASE_URL='https://the-internet.herokuapp.com'
+LOGIN_USERNAME=tomsmith
+LOGIN_PASSWORD=SuperSecretPassword!
+```

--- a/docs/RUNNING_NATIVELY.md
+++ b/docs/RUNNING_NATIVELY.md
@@ -20,14 +20,9 @@ Chrome be installed).
    ```
 
 ### Environment Variables
-#### Required Secrets
-`LOGIN_USERNAME=tomsmith`
-`LOGIN_PASSWORD=SuperSecretPassword!`
-
-**These must be set for the login test to pass.**
-
-> These are publicly available values but demonstrate
-> basic secret management
+#### Required Environment Variables and Secrets
+For the required secrets and other environment variables,
+see the [PREREQUISITES.md](PREREQUISITES.md)
 
 #### Specify Browser
 `BROWSER=`...
@@ -80,16 +75,16 @@ specified by `BROWSER` at the specified remote URL
 ### Examples of Running the Tests
 #### Defaults
 ```
-LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! bundle exec rake
+bundle exec rake
 ```
 
 ```
-LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! bundle exec cucumber
+bundle exec cucumber
 ```
 
 #### Local Browsers
 ```
-BROWSER=firefox HEADLESS=true LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! bundle exec rake
+BROWSER=firefox HEADLESS=true bundle exec rake
 ```
 
 #### Using the Selenium Standalone Containers
@@ -107,5 +102,5 @@ For specifics, see the Selenium Standalone Image
 2. If you want, launch the VNC client in app or browser
 3. Run the tests specifying the remote Selenium container...
    ```
-   REMOTE='http://localhost:4444/wd/hub' BROWSER=chrome LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! bundle exec cucumber
+   REMOTE='http://localhost:4444/wd/hub' BROWSER=chrome bundle exec cucumber
    ```

--- a/docs/RUNNING_WITH_OTHER_CONTAINERS.md
+++ b/docs/RUNNING_WITH_OTHER_CONTAINERS.md
@@ -3,13 +3,18 @@ You can also run the tests using other Selenium Standalone
 containers (such as Firefox and Edge) with the docker compose
 framework.
 
+### Prerequisites
+Before being able to run this project, you must follow the requirements
+in the [PREREQUISITES.md](PREREQUISITES.md)
+
+
 ### To Run Using the Firefox Standalone Container
 1. Ensure Docker is running
 2. From the project root directory, run the `dockercomposerun`
    script setting the `BROWSER` and `SELENIUM_IMAGE`
    environment variables to specify Firefox...
    ```
-   BROWSER=firefox SELENIUM_IMAGE=selenium/standalone-firefox LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun
+   BROWSER=firefox SELENIUM_IMAGE=selenium/standalone-firefox ./script/dockercomposerun
    ```
 
 ### To Run Using the Edge Standalone Container
@@ -18,5 +23,5 @@ framework.
    script setting the `BROWSER` and `SELENIUM_IMAGE`
    environment variables to specify Edge...
    ```
-   BROWSER=edge SELENIUM_IMAGE=selenium/standalone-edge LOGIN_USERNAME=tomsmith LOGIN_PASSWORD=SuperSecretPassword! ./script/dockercomposerun
+   BROWSER=edge SELENIUM_IMAGE=selenium/standalone-edge ./script/dockercomposerun
    ```

--- a/features/support/config.rb
+++ b/features/support/config.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Config
+  # Configuration for PageObject pages
+  module Pages
+    def page_base_url
+      ENV.fetch('BASE_URL')
+    end
+
+    def valid_login_username
+      ENV.fetch('LOGIN_USERNAME')
+    end
+
+    def valid_login_password
+      ENV.fetch('LOGIN_PASSWORD')
+    end
+  end
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -4,5 +4,13 @@ require 'rspec'
 require 'page-object'
 require 'eventually_helper'
 
+require_relative 'config'
+
+# This really needs be an include since we do want configuration global
+# and it throws an exception with World(Config::Pages)
+# rubocop:disable Style/MixinUsage
+include Config::Pages
+# rubocop:enable Style/MixinUsage
+
 World(PageObject::PageFactory)
 World(EventuallyHelper)

--- a/features/support/pages/login_page.rb
+++ b/features/support/pages/login_page.rb
@@ -2,16 +2,14 @@
 
 # The Sample Login Page
 class LoginPage < BasePage
-  page_url 'http://the-internet.herokuapp.com/login'
+  page_url "#{page_base_url}/login"
 
   text_field(:username,  name: 'username')
   text_field(:password,  name: 'password')
   button(:login_button, text: 'Login')
 
   def login_with_valid_credentials
-    valid_username = ENV.fetch('LOGIN_USERNAME')
-    valid_password = ENV.fetch('LOGIN_PASSWORD')
-    login_with_credentials(valid_username, valid_password)
+    login_with_credentials(valid_login_username, valid_login_password)
   end
 
   private

--- a/features/support/pages/secure_area_page.rb
+++ b/features/support/pages/secure_area_page.rb
@@ -4,5 +4,5 @@ require_relative 'base_page'
 
 # The Landing Page for Logging In
 class SecureAreaPage < BasePage
-  page_url 'http://the-internet.herokuapp.com/secure'
+  page_url "#{page_base_url}/secure"
 end


### PR DESCRIPTION
# What

This changeset is a "tipping point" refactor and when adding an additional environment variable
to supply the base URL for the pages used in the tests.

This changeset refactors and adds...
- A global configuration `module` with environment variables...
   - Existing `LOGIN_USERNAME`
   - Existing `LOGIN_PASSWORD`
   - New `BASE_URL`
- New `BASE_URL` environment variable to the
   - docker compose framework
   - GitHub Actions (PR CI)

# Why
The original reason was because the test started failing with...
```
      expected: "http://the-internet.herokuapp.com/login"
           got: "https://the-internet.herokuapp.com/login"
```

# Change Impact Analysis and Testing
Software changes are directed at the tests which will fail if any of them are incorrect, so CI Checks and running natively will verify and vet for regressions.  Documentation updates however will require execution of the changed commands following the changed documentation in context.

- [x] CI Checks vets URL update and refactor and new `BASE_URL`
- [x] Running locally natively URL update and refactor and new `BASE_URL`
- [x] Manual inspections of changed documentation in context vets documentation changes