### PR TITLE
Add Watir Browser Configuration (using environment variables) to the Global Config

### DIFF
--- a/features/support/config.rb
+++ b/features/support/config.rb
@@ -15,4 +15,20 @@ module Config
       ENV.fetch('LOGIN_PASSWORD')
     end
   end
+
+  # Configuration for Watir-driven browser
+  module Watir
+    def browser
+      ENV.fetch('BROWSER', nil)
+    end
+
+    def remote_browser_url
+      ENV.fetch('REMOTE', nil)
+    end
+
+    def headless?
+      # Support HEADLESS= as true, but HEADLESS=false as false
+      ENV.fetch('HEADLESS', false).to_s.downcase != 'false'
+    end
+  end
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -10,6 +10,7 @@ require_relative 'config'
 # and it throws an exception with World(Config::Pages)
 # rubocop:disable Style/MixinUsage
 include Config::Pages
+include Config::Watir
 # rubocop:enable Style/MixinUsage
 
 World(PageObject::PageFactory)

--- a/features/support/watir_browser.rb
+++ b/features/support/watir_browser.rb
@@ -1,43 +1,15 @@
 # frozen_string_literal: true
 
 def create_watir_browser
-  browser = specified_browser
-  remote_url = specified_remote_url
+  watir_browser_arguments = { options: browser_options }
+  # Handle local or remote (can not send url: nil)
+  watir_browser_arguments.merge!({ url: remote_browser_url }) if remote_browser_url
 
-  if remote_url
-    create_remote_browser(remote_url, browser)
-  else
-    create_local_browser(browser)
-  end
-end
-
-def create_remote_browser(remote_url, browser)
-  Watir::Browser.new browser, url: remote_url, options: browser_options
-end
-
-def create_local_browser(browser)
-  # Use the default watir (Chrome) browser if no browser is specified
-  return Watir::Browser.new unless browser
-
-  Watir::Browser.new(browser, options: browser_options)
+  Watir::Browser.new(browser, watir_browser_arguments)
 end
 
 def browser_options
   options = {}
-  options[:args] = ['--headless'] if headless_specified?
+  options[:args] = ['--headless'] if headless?
   options
-end
-
-def specified_browser
-  ENV['BROWSER']&.to_sym
-end
-
-def specified_remote_url
-  ENV.fetch('REMOTE', nil)
-end
-
-# Returns true if HEADLESS env var is set or not 'false'
-def headless_specified?
-  headless = ENV.fetch('HEADLESS', false)
-  headless.to_s.downcase != 'false'
 end


### PR DESCRIPTION
# What
This changeset completes adding global configuration by adding the Watir-browser configuration which uses environment variables...

- `BROWSER`
- `REMOTE`
- `HEADLESS` 

# Why
This now encapsulates all environment-variable-based configuration

# Change Impact Analysis and Testing
Software changes are directed at the tests which will fail if any of them are incorrect, so CI Checks and running natively will verify and vet for regressions.  Documentation updates however will require execution of the changed commands following the changed documentation in context.

- [x] CI Checks vets refactor of existing environment variables
- [x] Running locally natively vets refactor of existing environment variables
