### PR TITLE
Minor Maintenance for Consistency, Native Testing, Currency 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ FROM ruby-base AS builder
 ARG BASE_BUILD_PACKAGES='build-essential'
 
 # Use the same version of Bundler in the Gemfile.lock
-ARG BUNDLER_VERSION=2.4.21
+ARG BUNDLER_VERSION=2.4.22
 ENV BUNDLER_VERSION=${BUNDLER_VERSION}
 
 # Assumes debian based

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,12 +7,12 @@ GEM
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
     concurrent-ruby (1.2.2)
-    cucumber (9.0.2)
+    cucumber (9.1.0)
       builder (~> 3.2, >= 3.2.4)
       cucumber-ci-environment (~> 9.2, >= 9.2.0)
-      cucumber-core (~> 11.1, >= 11.1.0)
-      cucumber-cucumber-expressions (~> 16.1, >= 16.1.2)
-      cucumber-gherkin (>= 24, < 26.2.1)
+      cucumber-core (~> 12.0)
+      cucumber-cucumber-expressions (~> 17.0)
+      cucumber-gherkin (>= 24, < 27)
       cucumber-html-formatter (~> 20.4, >= 20.4.0)
       cucumber-messages (>= 19, < 23)
       diff-lcs (~> 1.5, >= 1.5.0)
@@ -20,28 +20,28 @@ GEM
       multi_test (~> 1.1, >= 1.1.0)
       sys-uname (~> 1.2, >= 1.2.3)
     cucumber-ci-environment (9.2.0)
-    cucumber-core (11.1.0)
-      cucumber-gherkin (>= 24, < 27)
-      cucumber-messages (>= 19, < 22)
-      cucumber-tag-expressions (~> 4.1, >= 4.1.0)
-    cucumber-cucumber-expressions (16.1.2)
+    cucumber-core (12.0.0)
+      cucumber-gherkin (>= 25, < 27)
+      cucumber-messages (>= 20, < 23)
+      cucumber-tag-expressions (~> 5.0, >= 5.0.4)
+    cucumber-cucumber-expressions (17.0.1)
     cucumber-gherkin (26.2.0)
       cucumber-messages (>= 19.1.4, < 22.1)
     cucumber-html-formatter (20.4.0)
       cucumber-messages (>= 18.0, < 22.1)
-    cucumber-messages (21.0.1)
-    cucumber-tag-expressions (4.1.0)
+    cucumber-messages (22.0.0)
+    cucumber-tag-expressions (5.0.6)
     data_magic (1.2)
       faker (>= 1.1.2)
       yml_reader (>= 0.6)
     diff-lcs (1.5.0)
     eventually_helper (0.0.2)
-    faker (3.2.1)
+    faker (3.2.2)
       i18n (>= 1.8.11, < 2)
     ffi (1.16.3)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    json (2.6.3)
+    json (2.7.0)
     language_server-protocol (3.17.0.3)
     mini_mime (1.1.5)
     multi_test (1.1.0)
@@ -54,7 +54,7 @@ GEM
     parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
-    racc (1.7.1)
+    racc (1.7.3)
     rainbow (3.1.1)
     rake (13.1.0)
     regexp_parser (2.8.2)
@@ -72,7 +72,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.1)
-    rubocop (1.57.2)
+    rubocop (1.58.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -80,7 +80,7 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.28.1, < 2.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.30.0)
@@ -97,7 +97,7 @@ GEM
       rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
-    selenium-webdriver (4.14.0)
+    selenium-webdriver (4.15.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -113,7 +113,6 @@ GEM
 
 PLATFORMS
   aarch64-linux
-  arm64-darwin-23
   ruby
   x86_64-linux
 
@@ -130,4 +129,4 @@ DEPENDENCIES
   selenium-webdriver
 
 BUNDLED WITH
-   2.4.21
+   2.4.22

--- a/script/dockercomposerun
+++ b/script/dockercomposerun
@@ -1,4 +1,5 @@
 #!/bin/sh
+# ----------------------------------------------------------------------
 # This script runs the project docker-compose framework.
 #
 # - The arguments to this script are passed to the browsertests service

--- a/script/mac-test-native-browsers
+++ b/script/mac-test-native-browsers
@@ -1,0 +1,103 @@
+#!/bin/bash
+# ----------------------------------------------------------------------
+# This script is intended for macOS and runs the project tests using
+# all browsers supported on Mac.  This script is for testing during
+# development on this project.
+# ----------------------------------------------------------------------
+
+prompt-to-proceed () {
+  read -p "Do you wish to proceed (Press any key to continue or 'n' to exit)? " response
+  if [[ $response == 'n' ]] || [[ $response == 'N' ]]; then
+    echo " buh-bye"
+    echo ""
+    exit
+  fi
+  echo ""
+}
+
+run_command () {
+  command_to_run="$@"
+  echo "  Executing [${command_to_run}]..."
+  $command_to_run
+  echo "  ... [${command_to_run}] completed"
+  echo ""
+}
+
+set_browser_env () {
+  export BROWSER="$@"
+  echo "BROWSER=${BROWSER-unset}"
+}
+
+set_headless_env () {
+  export HEADLESS="$@"
+  echo "HEADLESS=${HEADLESS-unset}"
+}
+
+load_if_dotenv_file () {
+  if [[ -f .env ]]; then
+    echo "Found .env file, loading it"
+    export $(cat .env | xargs)
+    echo ""
+  fi
+}
+
+### MAIN ###
+# Exit script on any errors
+set -e
+
+echo "Testing the NATIVE sample project - macOS only"
+echo ""
+
+load_if_dotenv_file
+
+echo "Running bundle install - DO NOT COMMIT Gemfile.lock"
+prompt-to-proceed
+run_command bundle install
+echo ""
+
+echo "Testing default"
+run_command bundle exec rake
+
+echo "Testing Chrome"
+set_browser_env chrome
+run_command bundle exec rake
+
+echo "Testing Chrome Headless"
+set_browser_env chrome
+set_headless_env
+run_command bundle exec rake
+set_headless_env false
+
+echo "Testing Edge"
+set_browser_env edge
+run_command bundle exec rake
+
+echo "Testing Edge Headless"
+set_browser_env edge
+set_headless_env foo
+run_command bundle exec rake
+set_headless_env false
+
+echo "Testing Firefox"
+set_browser_env firefox
+run_command bundle exec rake
+
+echo "Testing Firefox Headless"
+set_browser_env firefox
+set_headless_env true
+run_command bundle exec rake
+set_headless_env false
+
+echo "Testing Safari"
+set_browser_env safari
+run_command bundle exec rake
+
+echo "--- ALL TESTS PASSED ---"
+echo ""
+
+echo "Doing git checkout of Gemfile.lock"
+prompt-to-proceed
+run_command git checkout Gemfile.lock
+echo ""
+
+echo "--- FIN ---"


### PR DESCRIPTION
# What 
This maintenance changeset addresses comment consistency issues, adds a simple script for running the project tests with supported browsers natively on Mac, and updates `bundler` and gems to latest.

# Why
Consistency, easier development, and dependency currency.

# Change Impact Analysis and Testing

- [x] CI Checks pass vetting no regressions and gem updates
- [x] Use new `mac-test-native-browsers` to vet native execution
