### PR TITLE
Update Base Image to Debian Bookworm (12)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #-----------------------------------
 
 #--- Base Image ---
-ARG BASE_IMAGE=ruby:3.2.2-slim-bullseye
+ARG BASE_IMAGE=ruby:3.2.2-slim-bookworm
 FROM ${BASE_IMAGE} AS ruby-base
 
 # Install packages common to builder (dev) and deploy


### PR DESCRIPTION
# What
This changeset updates the base image to latest Debian release Bookworm (version 12).

# Why
Currency

# Change Impact Analysis and Testing
This changeset is limited to the project image.

- [ ] CI Checks vet images build and execute with no operational or functional regressions
  - [ ] CI Checks vet `amd64` images execute with no operational or functional regressions
- [ ] Running `arm64` image on Apple Silicon vets `arm64` images execute with no operational or functional regressions
