### PR TITLE
Add an Invalid Login Test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 gem 'bundler-audit', require: false
 gem 'cucumber'
+gem 'debug', '>= 1.0.0'
 gem 'eventually_helper'
 gem 'page-object'
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,9 @@ GEM
     data_magic (1.2)
       faker (>= 1.1.2)
       yml_reader (>= 0.6)
+    debug (1.9.1)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     diff-lcs (1.5.0)
     eventually_helper (0.0.2)
     faker (3.2.2)
@@ -41,6 +44,10 @@ GEM
     ffi (1.16.3)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    io-console (0.7.1)
+    irb (1.11.0)
+      rdoc
+      reline (>= 0.3.8)
     json (2.7.0)
     language_server-protocol (3.17.0.3)
     mini_mime (1.1.5)
@@ -54,10 +61,16 @@ GEM
     parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
+    psych (5.1.2)
+      stringio
     racc (1.7.3)
     rainbow (3.1.1)
     rake (13.1.0)
+    rdoc (6.6.2)
+      psych (>= 4.0.0)
     regexp_parser (2.8.2)
+    reline (0.4.1)
+      io-console (~> 0.5)
     rexml (3.2.6)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
@@ -101,6 +114,7 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    stringio (3.1.0)
     sys-uname (1.2.3)
       ffi (~> 1.1)
     thor (1.3.0)
@@ -119,6 +133,7 @@ PLATFORMS
 DEPENDENCIES
   bundler-audit
   cucumber
+  debug (>= 1.0.0)
   eventually_helper
   page-object
   rake

--- a/features/login.feature
+++ b/features/login.feature
@@ -1,6 +1,11 @@
 Feature: Secure User Login
 
-  Scenario: User logs in and is sent to the Secure Area
+  Scenario: Valid login
     Given user is on the login page
     When user logs in with valid credentials
     Then user must be sent to the Secure Area
+
+  Scenario: Invalid password
+    Given user is on the login page
+    When user logs in with invalid password
+    Then the error message "Your password is invalid!" is displayed

--- a/features/step_definitions/invalid_login_steps.rb
+++ b/features/step_definitions/invalid_login_steps.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+When('user logs in with invalid password') do
+  on(LoginPage).login_with_invalid_password
+end
+
+Then('the error message {string} is displayed') do |string|
+  expect(on(LoginPage).login_error).to include(string)
+end

--- a/features/step_definitions/valid_login_steps.rb
+++ b/features/step_definitions/valid_login_steps.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-When(/^user logs in with valid credentials/) do
+When('user logs in with valid credentials') do
   on(LoginPage).login_with_valid_credentials
 end
 
-Then(/^user must be sent to the Secure Area$/) do
+Then('user must be sent to the Secure Area') do
   on(SecureAreaPage) do |page|
     # An "eventually" matcher
     Timeout.timeout(5) do

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'debug'
 require 'rspec'
 require 'page-object'
 require 'eventually_helper'

--- a/features/support/pages/login_page.rb
+++ b/features/support/pages/login_page.rb
@@ -8,8 +8,14 @@ class LoginPage < BasePage
   text_field(:password,  name: 'password')
   button(:login_button, text: 'Login')
 
+  div(:login_error, id: 'flash')
+
   def login_with_valid_credentials
     login_with_credentials(valid_login_username, valid_login_password)
+  end
+
+  def login_with_invalid_password
+    login_with_credentials(valid_login_username, 'NotAValidPassword')
   end
 
   private

--- a/script/run
+++ b/script/run
@@ -38,7 +38,7 @@ wait_until_ready_if_remote_browser() {
   if [ ! -z "${REMOTE_STATUS}" ];
   then
     # This assumes curl and will not operate correctly without it
-    curl --version || (echo "ERROR: curl command is not found (127)" ; exit 127)
+    curl --version > /dev/null 2>&1 || (echo "ERROR: curl command is not found (127)" ; exit 127)
 
     COUNTER=0
     echo "Waiting for remote browser at [${REMOTE_STATUS}] to become available"


### PR DESCRIPTION
# What
This changeset...

1. Adds an invalid (password) login test
2. Mutes the output of the `curl` present check
3. Adds the [`debug`](https://github.com/ruby/debug) gem
4. Updates step definitions to more modern Cucumber

# Why
* The invalid login test demonstrates how to verify an error response and provides a logical counterpoint to a valid login
* The extraneous and verbose output during the `curl` check was distracting
* The addition of the `debug` gem makes debugging during development easier
* Updating step definitions to more modern Cucumber presents and leverages current standards

# Change Impact Analysis and Testing

- [x] CI Checks vets newly added test and no regressions to existing behavior as well as code quality and standards
- [x] Native execution (Apple Silicon) vets newly added test and no regressions to existing behavior
- [x] Inspection of CI Checks and local run of `dockercomposerun` vets `curl` check output is silenced
- [x] Usage of `debug` gem natively vets its correct addition
