### PR TITLE
Suspend MS Edge Browser Support

### DIFF
--- a/.github/workflows/on_pr_build_push_vet_images.yml
+++ b/.github/workflows/on_pr_build_push_vet_images.yml
@@ -69,7 +69,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browser: [chrome, firefox, edge]
+        # MS Edge is currently not supported per brianjbayer/sample-login-watir-cucumber#83
+        # browser: [chrome, firefox, edge]
+        browser: [chrome, firefox]
     runs-on: ubuntu-latest
     env:
       UNVETTED_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_unvetted:${{ github.event.pull_request.head.sha }}
@@ -104,7 +106,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browser: [chrome, firefox, edge]
+        # MS Edge is currently not supported per brianjbayer/sample-login-watir-cucumber#83
+        # browser: [chrome, firefox, edge]
+        browser: [chrome, firefox]
     runs-on: ubuntu-latest
     env:
       DEVENV_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # sample-login-watir-cucumber
 
+## Overview
+
+> :unamused: Currently Microsoft Edge Browser is not supported
+> in this project per brianjbayer/sample-login-watir-cucumber#83
+
 This is an example of End-To-End (E2E) Tests/Acceptance Test
 Driven Development (ATDD) using
 [Watir](http://watir.com), [Cucumber](https://cucumber.io),

--- a/script/dockercomposerun
+++ b/script/dockercomposerun
@@ -71,7 +71,7 @@ if [ -z ${noselenium} ]; then
   echo "...Adding Selenium Browser to Environment"
   docker_compose_command="${docker_compose_command} -f docker-compose.selenium.yml "
 
-  if [[ `uname -m` == "arm64" ]]; then
+if [ `uname -m` = "arm64" ]; then
     echo "...Apple Silicon Detected adding Seleniarm Browser Override to Environment"
     docker_compose_command="${docker_compose_command} -f docker-compose.seleniarm.yml "
   fi


### PR DESCRIPTION
# What
This changeset suspends official project support for the Microsoft Edge browser.  It is unfortunate that some companies are more interested in selling a product instead of making a product worth selling.

Things may change in the future, so I am commenting out the support instead of fully removing it.  It may also be of use as a potential reference.

In addition, this changeset addresses a bug where double brackets (`[[ ... ]]`) were used instead of single brackets (`[ ... ]`) in the `dockercomposerun` script which is `sh`ell and not `bash`.

# Why
Support for MS Edge is being suspended due to...
1. Its user-experience disruptive **_Personalize your web experience_** popup which would require browser-specific customization
2. This [Selenium issue](https://github.com/SeleniumHQ/docker-selenium/issues/2052) which seems to be triggered in the CI Run
3. Unable to run the `selenium-standalone-edge` browser image on Apple Silicon

I added MS Edge support as a nice to have but as seems to be common with Microsoft, we can not have nice things.

# Change Impact Analysis and Testing

- [x] CI Checks vet no regressions
- [x] Inspection of CI Checks output verifies CI is not using MS Edge and fix of single brackets
- [x] Successful execution and inspection of output of native (Apple Silicon) run of `dockercomposerun` ensures fix of single brackets results in no regressions
- [x] Manual inspection of rendered README on this branch verifies documentation update
