### PR TITLE
Update Bundler and Gems to Latest 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ FROM ruby-base AS builder
 ARG BASE_BUILD_PACKAGES='build-essential'
 
 # Use the same version of Bundler in the Gemfile.lock
-ARG BUNDLER_VERSION=2.4.22
+ARG BUNDLER_VERSION=2.5.3
 ENV BUNDLER_VERSION=${BUNDLER_VERSION}
 
 # Assumes debian based

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GEM
     irb (1.11.0)
       rdoc
       reline (>= 0.3.8)
-    json (2.7.0)
+    json (2.7.1)
     language_server-protocol (3.17.0.3)
     mini_mime (1.1.5)
     multi_test (1.1.0)
@@ -57,7 +57,7 @@ GEM
       watir (>= 6.10.3)
     page_navigation (0.10)
       data_magic (>= 0.22)
-    parallel (1.23.0)
+    parallel (1.24.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
@@ -68,7 +68,7 @@ GEM
     rake (13.1.0)
     rdoc (6.6.2)
       psych (>= 4.0.0)
-    regexp_parser (2.8.2)
+    regexp_parser (2.8.3)
     reline (0.4.1)
       io-console (~> 0.5)
     rexml (3.2.6)
@@ -85,7 +85,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.1)
-    rubocop (1.58.0)
+    rubocop (1.59.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -110,7 +110,7 @@ GEM
       rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
-    selenium-webdriver (4.15.0)
+    selenium-webdriver (4.16.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -144,4 +144,4 @@ DEPENDENCIES
   selenium-webdriver
 
 BUNDLED WITH
-   2.4.22
+   2.5.3


### PR DESCRIPTION
# What
This changeset updates `bundler` to `2.5.3` (latest) as well as any other gems to latest.

# Why
Maintaining currency makes future updates easier with less risk.

# Change Impact Analysis and Testing

- [x] CI Checks vet no regressions and code quality
- [x] Native (Apple Silicon) vets no regressions and ability to run natively 


