### PR TITLE
Use Cross-Compilation in Multi Platform Builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 #--- Base Image ---
 ARG BASE_IMAGE=ruby:3.2.4-slim-bookworm
-FROM ${BASE_IMAGE} AS ruby-base
+FROM --platform=$BUILDPLATFORM ${BASE_IMAGE} AS ruby-base
 
 # Install packages common to builder (dev) and deploy
 ARG BASE_PACKAGES='curl'


### PR DESCRIPTION
# What & Why
This is a one-line change to the Dockerfile to use cross-compiltion to decrease the elapsed time of multi-platform builds (especially in CI) as reommended in the [Faster Multi-Platform Builds: Dockerfile Cross-Compilation Guide](https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide) by Docker.


# Change Impact Analysis and Testing
This change is based upon Prior Art and demonstrated ability of `buildx`.

- [x] Inspection of image build in CI Checks verifies cross-compilation
  - [x] Improvement in multi-platform image building
    - [x] Deploy Image - [Current:](https://github.com/brianjbayer/sample-login-watir-cucumber/actions/runs/9429612586/job/25976200496?pr=90) **57s** vs   [Previous:](https://github.com/brianjbayer/sample-login-watir-cucumber/actions/runs/9236712081/job/25412859768) 12m 35s
    - [x] Dev Image - [Current:](https://github.com/brianjbayer/sample-login-watir-cucumber/actions/runs/9429612586/job/25976200404?pr=90) **1m 32s** vs   [Previous:](https://github.com/brianjbayer/sample-login-watir-cucumber/actions/runs/9236712081/job/25412859740) 13m 28s
- [x] CI Checks vet there are no regressions in `amd64`
- [x] Local (Apple Silicon) image operations vets there are no regressions in `arm64`...
  - [x] Dev Image - `BROWSERTESTS_IMAGE=brianjbayer/sample-login-watir-cucumber_cross-compile-in-multiplatform-builds_dev:d0d4b0935934db006deae6d4e77bc5deb2a392e0 ./script/dockercomposerun ./script/run tests` 
  - [x] Deploy Image - `BROWSERTESTS_IMAGE=brianjbayer/sample-login-watir-cucumber_cross-compile-in-multiplatform-builds:d0d4b0935934db006deae6d4e77bc5deb2a392e0 ./script/dockercomposerun`
- [x] Local (Apple Silicon) image build and operation vets there are no regressions in `arm64`
  - [x] Dev Image
  - [x] Deploy Image
