### PR TITLE
Revert False Cross-Compilation in Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 #--- Base Image ---
 ARG BASE_IMAGE=ruby:3.2.4-slim-bookworm
-FROM --platform=$BUILDPLATFORM ${BASE_IMAGE} AS ruby-base
+FROM ${BASE_IMAGE} AS ruby-base
 
 # Install packages common to builder (dev) and deploy
 ARG BASE_PACKAGES='curl'


### PR DESCRIPTION
# What
This one-line change reverts brianjbayer/sample-login-watir-cucumber#90 by removing `--platform=$BUILDPLATFORM` from the `Dockerfile` base image directive.

# Why
The `--platform=$BUILDPLATFORM` causes a false build of the `linux/arm64` platform image using the `BUILDPLATFORM` which is `linux/amd64` (ubuntu runner) .  This reverts that regression.  Note that most operations do still work but only by chance.

# Change Impact Analysis and Testing
This simply takes things back to before brianjbayer/sample-login-watir-cucumber#90

- [x] Verify there is no difference between this commit and (merge) commit prior to brianjbayer/sample-login-watir-cucumber#90 with `gd 5cf087288c300d289747375cb70963c928348189..HEAD` returning empty
