### PR TITLE
Update to current dockercomposerun Standards

### DIFF
--- a/.github/workflows/on_pr_build_push_vet_images.yml
+++ b/.github/workflows/on_pr_build_push_vet_images.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: dockercomposerun rubocop on development environment
-        run: "BROWSERTESTS_IMAGE=${DEVENV_IMAGE} ./script/dockercomposerun -n -d ./script/run lint"
+        run: "BROWSERTESTS_IMAGE=${DEVENV_IMAGE} ./script/dockercomposerun -do ./script/run lint"
 
   vet-dependency-security:
     needs: [pr-norm-branch, buildx-and-push-branch-devenv]
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: dockercomposerun bundle-audit on development environment
-        run: "BROWSERTESTS_IMAGE=${DEVENV_IMAGE} ./script/dockercomposerun -n -d ./script/run secscan"
+        run: "BROWSERTESTS_IMAGE=${DEVENV_IMAGE} ./script/dockercomposerun -do ./script/run secscan"
 
   vet-deploy-e2e-tests-matrix:
     needs: [pr-norm-branch, buildx-and-push-branch-unvetted]

--- a/script/dockercomposerun
+++ b/script/dockercomposerun
@@ -1,129 +1,89 @@
 #!/bin/sh
-# ----------------------------------------------------------------------
-# This script runs the project docker-compose framework.
-#
-# - The arguments to this script are passed to the browsertests service
-#   as command override
-#
-# - Any environment variables set when calling this script are passed
-#   through to the docker-compose framework
-#   (e.g. configuration other than the defaults)
-#
-# OPTIONS:
-# -c: Use the docker-compose CI environment with BROWSERTESTS_IMAGE
-# -d: Use the docker-compose Dev environment with BROWSERTESTS_IMAGE
-# -n: No Selenium browser in the docker-compose environment
-# ----------------------------------------------------------------------
-
-usage() {
-  echo "Usage: $0 [-cdn] [CMD]"
-}
-
-err_exit() {
-  local err_msg="$1"
-  local err_code=$2
-  echo "${err_msg}  --  Exit:[${err_code}]" 1>&2
-  usage
-  exit $err_code
-}
 
 # Exit script on any errors
 set -e
 
+usage() {
+  cat << USAGE
+Usage: $0 [-cdho] [CMD]
+
+This script orchestrates 'docker compose run browsertests' using the docker compose framework
+  * Arguments are passed to the app service as the CMD (entrypoint)
+  * Environment variables override app and framework defaults
+
+OPTIONS: (in override order)
+  -o: Run only the browsertests service (no Selenium Browser)
+  -d: Run the docker-compose Dev environment
+  -c: Run the docker-compose CI environment (must specify BROWSERTESTS_IMAGE)
+USAGE
+}
+
+err_exit() {
+  err_code=$1
+  err_msg="$2"
+  echo "${err_msg}  --  Exit:[${err_code}]" 1>&2
+  exit $err_code
+}
+
 # Handle options
-while getopts ":cdn" options; do
+while getopts ":cdho" options; do
   case "${options}" in
     c)
-      echo "CI Environment"
-      ci=true
+      ci=1
       ;;
     d)
-      echo "Development Environment"
-      devenv=true
+      devenv=1
       ;;
-    n)
-      echo "No Selenium"
-      noselenium=true
+    h)
+      usage ; exit
+      ;;
+    o)
+      browsertests_only=1
       ;;
     \?)
-    err_exit "Invalid Option: -$OPTARG" 1
+      usage
+      err_exit 1 "Invalid Option: -$OPTARG"
       ;;
   esac
 done
 shift $((OPTIND-1))
 
-echo ''
-echo "ENVIRONMENT VARIABLES..."
-env
-echo ''
+echo "DOCKER VERSION: [`docker --version`]"
+docker_compose_command='docker compose -f docker-compose.yml '
 
-echo 'DOCKER VERSION...'
-docker --version
-docker-compose --version
-echo ''
-
-# Override docker compose environments
-echo 'DOCKER-COMPOSE COMMAND...'
-docker_compose_command='docker-compose -f docker-compose.yml '
-
-# Unless the no selenium option is set, use Selenium browser
-if [ -z ${noselenium} ]; then
-  echo "...Adding Selenium Browser to Environment"
+if [ -z ${browsertests_only} ] ; then
   docker_compose_command="${docker_compose_command} -f docker-compose.selenium.yml "
-
-if [ `uname -m` = "arm64" ]; then
-    echo "...Apple Silicon Detected adding Seleniarm Browser Override to Environment"
-    docker_compose_command="${docker_compose_command} -f docker-compose.seleniarm.yml "
-  fi
+  [ `uname -m` == "arm64" ] && docker_compose_command="${docker_compose_command} -f docker-compose.seleniarm.yml "
 fi
 
-if [ ! -z ${ci} ]; then
-  echo "...Using CI Environment with Image [${BROWSERTESTS_IMAGE}]"
-  docker_compose_command="${docker_compose_command} -f docker-compose.ci.yml "
-fi
+[ ! -z ${devenv} ] && docker_compose_command="${docker_compose_command} -f docker-compose.dev.yml "
+[ ! -z ${ci} ] && docker_compose_command="${docker_compose_command} -f docker-compose.ci.yml "
 
-if [ ! -z ${devenv} ]; then
-  echo "...Using Development Environment with Image [${BROWSERTESTS_IMAGE}]"
-  docker_compose_command="${docker_compose_command} -f docker-compose.dev.yml "
-fi
-echo "...COMMAND: [${docker_compose_command}]"
-echo ''
+# Default is to run the browsertests, but must specify --service-ports
+# (by default docker compose run does not expose host ports)
+run_command='run --rm --service-ports browsertests '
 
-echo 'DOCKER-COMPOSE CONFIGURATION...'
+docker_compose_run_command="${docker_compose_command} ${run_command}"
+echo "DOCKER COMPOSE RUN COMMAND: [${docker_compose_run_command}]"
+
+echo 'DOCKER COMPOSE CONFIGURATION...'
 $docker_compose_command config
-echo ''
 
-echo 'DOCKER-COMPOSE PULLING...'
-set +e
-$docker_compose_command pull
-echo '...Allowing pull errors (for local images)'
-set -e
-echo ''
+echo 'DOCKER COMPOSE PULLING...'
+set +e ; $docker_compose_command pull ; set -e
 
-echo 'DOCKER IMAGES...'
-docker images
-echo ''
-
-echo "DOCKER-COMPOSE RUNNING [$@]..."
+echo "DOCKER COMPOSE RUNNING [${docker_compose_run_command}] [$@]..."
 # Allow to fail but catch return code
 set +e
-$docker_compose_command run --rm browsertests "$@"
+${docker_compose_run_command} "$@"
 run_return_code=$?
-# NOTE return code must be caught before any other command
 set -e
-echo ''
 
-if [ $run_return_code -eq 0 ]; then
-    run_disposition='PASSED'
-else
-    run_disposition='FAILED'
-fi
-echo "...RUN [${run_disposition}] WITH RETURN CODE [${run_return_code}]"
-echo ''
+run_disposition='SUCCESS' ; [ $run_return_code -eq 0 ] || run_disposition='FAIL'
+echo "DOCKER COMPOSE RUN [${run_disposition}] WITH RETURN CODE [${run_return_code}]"
 
 echo 'DOCKER-COMPOSE DOWN...'
 $docker_compose_command down
-echo ''
 
-echo "EXITING WITH ${run_disposition} RUN RETURN CODE ${run_return_code}"
+echo "EXIT: ${run_disposition} [${run_return_code}]"
 exit $run_return_code


### PR DESCRIPTION
# What & Why
This changeset updates the `dockercomposerun` and its PR Checks usage to current standards of command line options and code brevity.

# Change Impact Analysis and Testing

- [x] Successful PR Checks verify changes introduce no regressions for options `-c`, `-d`, `-o`
- [x] Successful Manual (local) execution of the following verifies no regressions for...
  - [x] default with `./script/dockercomposerun`
  - [x] help/usage with `./script/dockercomposerun -h`
