### PR TITLE
Add a Ruby-based General wait_on_endpoint Orcehstration Script for Running Tests

### DIFF
--- a/.github/workflows/on_pr_build_push_vet_images.yml
+++ b/.github/workflows/on_pr_build_push_vet_images.yml
@@ -78,7 +78,7 @@ jobs:
     uses: ./.github/workflows/run-e2e-tests.yml
     with:
       e2e_tests_image: ${{ needs.image-names.outputs.dev_image }}
-      e2e_tests_command: "./script/dockercomposerun -d ./script/run tests"
+      e2e_tests_command: "./script/dockercomposerun -d bash -c './wait_on_endpoint && bundle exec cucumber'"
     secrets:
       login_username: ${{ secrets.LOGIN_USERNAME }}
       login_password: ${{ secrets.LOGIN_PASSWORD }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ ARG BASE_IMAGE=ruby:3.3.4-slim-bookworm
 FROM ${BASE_IMAGE} AS ruby-base
 
 # Install packages common to builder (dev) and deploy
-ARG BASE_PACKAGES='curl'
 
 # Assumes debian based
 RUN apt-get update \
@@ -89,4 +88,5 @@ WORKDIR /app
 COPY --chown=deployer . /app/
 
 # Run the tests but allow override
-CMD ["./script/run", "tests"]
+# Expects the wait_on_endpoint script environment variables to be set
+CMD ["bash", "-c", "./wait_on_endpoint && bundle exec cucumber"]

--- a/docker-compose.selenium.yml
+++ b/docker-compose.selenium.yml
@@ -4,7 +4,7 @@ services:
       - BROWSER=${BROWSER:-chrome}
       - HEADLESS
       - REMOTE=http://${SELENIUM_HOSTNAME:-seleniumbrowser}:4444/wd/hub
-      - REMOTE_STATUS=http://${SELENIUM_HOSTNAME:-seleniumbrowser}:4444/wd/hub/status
+      - WAIT_ON_ENDPOINT=${WAIT_ON_ENDPOINT:-http://seleniumbrowser:4444/wd/hub/status}
     depends_on:
       - seleniumbrowser
 

--- a/script/run
+++ b/script/run
@@ -34,28 +34,6 @@ run_and_exit_return_code () {
   exit $run_return_code
 }
 
-wait_until_ready_if_remote_browser() {
-  if [ ! -z "${REMOTE_STATUS}" ];
-  then
-    # This assumes curl and will not operate correctly without it
-    curl --version > /dev/null 2>&1 || (echo "ERROR: curl command is not found (127)" ; exit 127)
-
-    COUNTER=0
-    echo "Waiting for remote browser at [${REMOTE_STATUS}] to become available"
-    until curl -fsSL "${REMOTE_STATUS}" >/dev/null 2>&1; do
-      printf "."
-      sleep 1
-      COUNTER=$((COUNTER + 1))
-      if [ $COUNTER -eq 30 ] ; then
-        echo "✘"
-        echo "ERROR: Timed out waiting for remote browser (99)"
-        exit 99
-      fi
-    done
-    echo "✔"
-  fi
-}
-
 # ------------
 # --- MAIN ---
 # ------------
@@ -77,7 +55,6 @@ case "$action" in
 
   "tests")
     shift
-    wait_until_ready_if_remote_browser
     run_command="bundle exec cucumber $@"
   ;;
 esac

--- a/wait_on_endpoint
+++ b/wait_on_endpoint
@@ -1,0 +1,43 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# ----------------------------------------------------------------------
+# Simple script to query healthchecks of locally running Ruby
+#  applications. Generally intended as a healthchecks for
+# container orchestration so curl/wget are not needed
+# ----------------------------------------------------------------------
+require 'net/http'
+require 'uri'
+
+# --- Methods ---
+def get_response(endpoint)
+  Net::HTTP.get_response(endpoint)
+rescue StandardError
+  # Ignore no response
+end
+
+# --- Main ---
+endpoint = ARGV.shift || ENV.fetch('WAIT_ON_ENDPOINT', nil)
+unless endpoint
+  warn 'Error: requires an endpoint'
+  exit(1)
+end
+
+wait_on_endpoint = URI.parse(endpoint)
+
+wait_time = ENV.fetch('WAIT_ON_WAIT', 30).to_i
+
+response = wait_time.times do
+  response = get_response(wait_on_endpoint)
+  break response if response
+
+  print '.'
+  $stdout.flush
+  sleep 1
+end
+
+# Timeout
+exit(86) if response == wait_time
+
+expected_response_code = ENV.fetch('WAIT_ON_RESPONSE_CODE', '200')
+exit(response.code == expected_response_code ? 0 : 3)


### PR DESCRIPTION
# What & Why

> 📖 This changeset is based on prior art brianjbayer/sample-login-capybara-rspec#120

This changeset changes the level of orchestration between the project tests and the (potentially) remote browser occur:
* Adds a new general Ruby-based `wait_on_endpoint` script for orchestration with a remote endpoint
* Deprecates the shell-based orchestration in the `run` script for the `tests` argument
* Removes `curl` from the Development and Deployment images

This both removes a dependency on `curl` (and its size in the image) and lessens the threat surface.  It also offers better separation of concerns between the tests and their operating environment. 

# Change Impact Analysis and Testing

- [x] Changes to the `Dockerfile` file will be verified from building exercising in the PR Checks which have also been updated to use the new script is used which is also used directly in the deployment image CMD