### PR TITLE
Update to actions-image-cicd v0.2.2

### DIFF
--- a/.github/workflows/on_pr_build_push_vet_images.yml
+++ b/.github/workflows/on_pr_build_push_vet_images.yml
@@ -11,7 +11,7 @@ jobs:
 
   image-names:
     name: PR (Branch) Image Names
-    uses: brianjbayer/actions-image-cicd/.github/workflows/image_names.yml@v0.2.1
+    uses: brianjbayer/actions-image-cicd/.github/workflows/image_names.yml@v0.2.2
     with:
       add_branch_name: true
 
@@ -21,7 +21,7 @@ jobs:
     name: Build Development Image
     needs:
       - image-names
-    uses: brianjbayer/actions-image-cicd/.github/workflows/buildx_push_image.yml@v0.2.1
+    uses: brianjbayer/actions-image-cicd/.github/workflows/buildx_push_image.yml@v0.2.2
     with:
       image: ${{ needs.image-names.outputs.dev_image }}
       platforms: "linux/amd64,linux/arm64"
@@ -34,7 +34,7 @@ jobs:
     name: Build Deployment (Unvetted) Image
     needs:
       - image-names
-    uses: brianjbayer/actions-image-cicd/.github/workflows/buildx_push_image.yml@v0.2.1
+    uses: brianjbayer/actions-image-cicd/.github/workflows/buildx_push_image.yml@v0.2.2
     with:
       image: ${{ needs.image-names.outputs.unvetted_image }}
       platforms: "linux/amd64,linux/arm64"
@@ -50,7 +50,7 @@ jobs:
     needs:
       - image-names
       - buildx-and-push-dev-image
-    uses: brianjbayer/actions-image-cicd/.github/workflows/vet_code_standards.yml@v0.2.1
+    uses: brianjbayer/actions-image-cicd/.github/workflows/vet_code_standards.yml@v0.2.2
     with:
       lint_command: "BROWSERTESTS_IMAGE=${{ needs.image-names.outputs.dev_image }} ./script/dockercomposerun -do ./script/run lint"
       dependency_security_command: "BROWSERTESTS_IMAGE=${{ needs.image-names.outputs.dev_image }} ./script/dockercomposerun -do ./script/run secscan"
@@ -91,7 +91,7 @@ jobs:
       - image-names
       - vet-lint-and-dependency-security
       - vet-e2e-tests-deployment
-    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@v0.2.1
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@v0.2.2
     with:
       source_image: ${{ needs.image-names.outputs.unvetted_image }}
       target_image: ${{ needs.image-names.outputs.vetted_image }}

--- a/.github/workflows/on_push_to_main_promote_to_prod.yml
+++ b/.github/workflows/on_push_to_main_promote_to_prod.yml
@@ -10,13 +10,13 @@ jobs:
 
   branch-and-last-commit:
     name: Merged Branch and Last Commit
-    uses: brianjbayer/actions-image-cicd/.github/workflows/get_merged_branch_last_commit.yml@v0.2.1
+    uses: brianjbayer/actions-image-cicd/.github/workflows/get_merged_branch_last_commit.yml@v0.2.2
 
   merged-image-names:
     name: Merged (Branch) Image Names
     needs:
       - branch-and-last-commit
-    uses: brianjbayer/actions-image-cicd/.github/workflows/image_names.yml@v0.2.1
+    uses: brianjbayer/actions-image-cicd/.github/workflows/image_names.yml@v0.2.2
     with:
       add_branch_name: true
       branch_name: ${{ needs.branch-and-last-commit.outputs.branch }}
@@ -26,7 +26,7 @@ jobs:
     name: Production Image Names
     needs:
       - branch-and-last-commit
-    uses: brianjbayer/actions-image-cicd/.github/workflows/image_names.yml@v0.2.1
+    uses: brianjbayer/actions-image-cicd/.github/workflows/image_names.yml@v0.2.2
     with:
       tag: ${{ needs.branch-and-last-commit.outputs.commit }}
 
@@ -38,7 +38,7 @@ jobs:
     needs:
       - merged-image-names
       - production-image-names
-    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@v0.2.1
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@v0.2.2
     with:
       source_image: ${{ needs.merged-image-names.outputs.vetted_image }}
       target_image: ${{ needs.production-image-names.outputs.vetted_image }}
@@ -51,7 +51,7 @@ jobs:
     needs:
       - production-image-names
       - promote-merged-deploy-image
-    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest.yml@v0.2.1
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest.yml@v0.2.2
     with:
       image: ${{ needs.production-image-names.outputs.vetted_image }}
     secrets:
@@ -64,7 +64,7 @@ jobs:
     needs:
       - merged-image-names
       - production-image-names
-    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@v0.2.1
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@v0.2.2
     with:
       source_image: ${{ needs.merged-image-names.outputs.dev_image }}
       target_image: ${{ needs.production-image-names.outputs.dev_image }}
@@ -77,7 +77,7 @@ jobs:
     needs:
       - production-image-names
       - promote-merged-dev-image
-    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest.yml@v0.2.1
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest.yml@v0.2.2
     with:
       image: ${{ needs.production-image-names.outputs.dev_image }}
     secrets:


### PR DESCRIPTION
# What & Why
This changeset updates to the latest version (`v0.2.2`) of the `actions-image-cicd` Reusable Workflows used in the PR and Merge Checks to maintain currency.  This new version displays the image names of the promoted images.


# Change Impact Analysis and Testing

- [x] Successful inspected PR Checks
- [ ] Successful inspected Merge Checks