### PR TITLE
Add Support For Running in Parallel

### DIFF
--- a/.github/workflows/on_pr_build_push_vet_images.yml
+++ b/.github/workflows/on_pr_build_push_vet_images.yml
@@ -75,7 +75,7 @@ jobs:
     uses: ./.github/workflows/run-e2e-tests.yml
     with:
       e2e_tests_image: ${{ needs.image-names.outputs.dev_image }}
-      e2e_tests_command: "./script/dockercomposerun -d bash -c './wait_on_endpoint && bundle exec cucumber'"
+      e2e_tests_command: "./script/dockercomposerun -d bash -c './wait_on_endpoint && ./script/run -p tests'"
     secrets:
       login_username: ${{ secrets.LOGIN_USERNAME }}
       login_password: ${{ secrets.LOGIN_PASSWORD }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,4 +81,4 @@ COPY --chown=deployer . /app/
 
 # Run the tests but allow override
 # Expects the wait_on_endpoint script environment variables to be set
-CMD ["bash", "-c", "./wait_on_endpoint && bundle exec cucumber"]
+CMD ["bash", "-c", "./wait_on_endpoint && ./script/run -p tests"]

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'debug', '>= 1.0.0'
 gem 'eventually_helper'
 gem 'ostruct'
 gem 'page-object'
+gem 'parallel_tests'
 gem 'rake'
 gem 'rspec'
 gem 'rubocop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,8 @@ GEM
     page_navigation (0.10)
       data_magic (>= 0.22)
     parallel (1.27.0)
+    parallel_tests (5.4.0)
+      parallel
     parser (3.3.9.0)
       ast (~> 2.4.1)
       racc
@@ -157,6 +159,7 @@ DEPENDENCIES
   eventually_helper
   ostruct
   page-object
+  parallel_tests
   rake
   rspec
   rubocop

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@
 require 'bundler/audit/task'
 require 'cucumber'
 require 'cucumber/rake/task'
+require 'parallel_tests/tasks'
 require 'rubocop/rake_task'
 require 'rubygems'
 
@@ -17,8 +18,22 @@ task :checks do
   Rake::Task['bundle:audit'].invoke
 end
 
-# Set (Cucumber) features as default
-Cucumber::Rake::Task.new(:features) do |t|
+# Cucumber Tasks
+Cucumber::Rake::Task.new(:cucumber) do |t|
   t.profile = 'default'
 end
-task default: :features
+
+namespace :cucumber do
+  desc 'Run Cucumber features in parallel using parallel_tests'
+  task :parallel do
+    if ENV['BROWSER'] == 'safari'
+      warn 'rake: running specs SEQUENTIALLY for safari'
+      Rake::Task[:cucumber].invoke
+    else
+      Rake::Task['parallel:features'].invoke
+    end
+  end
+end
+
+# Set the Default to running in parallel
+task default: 'cucumber:parallel'

--- a/docker-compose.selenium.yml
+++ b/docker-compose.selenium.yml
@@ -11,13 +11,18 @@ services:
   seleniumbrowser:
     # The selenium/standalone-chromium image is multiplatform (arm64)
     image: ${SELENIUM_IMAGE:-selenium/standalone-chromium:latest}
+    platform: ${SELENIUM_IMAGE_PLATFORM:-}
     container_name: ${SELENIUM_HOSTNAME:-seleniumbrowser}
-    shm_size: 2gb
+    # shm size should be considered with parallelism
+    shm_size: 4gb
     volumes:
       - /dev/shm:/dev/shm
     ports:
       - "5900:5900"
       - "7900:7900"
+    environment:
+      # The number of browser sessions should correspond to parallelism
+      - SE_NODE_MAX_SESSIONS=2
     healthcheck:
       test: ["CMD-SHELL", '/opt/bin/check-grid.sh --host 0.0.0.0 --port 4444']
       interval: 15s

--- a/script/run
+++ b/script/run
@@ -1,13 +1,35 @@
 #!/bin/sh
-# -----------------------------------------------
-# Project run script to run
-#   - lint
-#   - secscan
-#   - tests
-#   - or it runs all arguments
-# -----------------------------------------------
+
+# Project Commands
+be='bundle exec'
+lint_cmd="${be} rubocop"
+secscan_cmd="${be} bundle-audit check --update"
+tests_cmd="${be} cucumber"
+parallel_tests_cmd="${be} parallel_cucumber"
+
+usage() {
+  cat << USAGE
+Usage: $0 [-hp] [CMD] [ARG...]
+This is the project "run" script, executing common application tasks.
+
+If the CMD is not recognized, it runs all arguments as a command:
+  * lint:           Run the linter [$lint_cmd]
+
+  * secscan:        Run the security scanner [$secscan_cmd]
+
+  * tests:          Run the tests (cucumber) [$tests_cmd]
+                    (in parallel if -p specified) [$parallel_tests_cmd]
+
+  * [CMD] [ARG...]: Run any other command with arguments
+
+OPTIONS: (in override order)
+  -h: Show this help message
+  -p: if supported by the CMD, runs in parallel
+USAGE
+}
 
 # --- Functions ---
+
 run_and_exit_return_code () {
   # Exit script on any errors
   set -e
@@ -40,22 +62,39 @@ run_and_exit_return_code () {
 # Exit script on any errors
 set -e
 
+while getopts ":hp" options; do
+  case "${options}" in
+    p)
+      parallel=1
+      ;;
+    h)
+      usage ; exit
+      ;;
+    \?)
+      usage
+      err_exit 1 "Invalid Option: -$OPTARG"
+      ;;
+  esac
+done
+shift $((OPTIND-1))
+
 # set run command if recognized action
 action="${1}"
 case "$action" in
   "lint")
     shift
-    run_command="bundle exec rubocop $@"
+    run_command="${lint_cmd} $@"
   ;;
 
   "secscan")
     shift
-    run_command="bundle exec bundle-audit check --update $@"
+    run_command="${secscan_cmd} $@"
   ;;
 
   "tests")
     shift
-    run_command="bundle exec cucumber $@"
+    run_command="${tests_cmd} $@"
+    [ -n "${parallel}" ] && run_command="${parallel_tests_cmd} $@"
   ;;
 esac
 


### PR DESCRIPTION
# What
This changeset adds the ability to run these tests in parallel using the `parallel_tests` gem.

The default rake task `bundle exec rake` now runs the test in parallel unless the `BROWSER=safari`.  Safari does not support multiple sessions on a machine (macOS).

# Change Impact Analysis and Testing

- [x] Successful PR Checks and their inspection to verify parallel execution verifies parallel ability and ./script/run -p tests`
- [x] Local native macOS (Apple silicon) verifies native execution and default rake task
