### PR TITLE
Bundler 4.0.6, gems latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG BASE_IMAGE=ruby:4.0.1-slim-trixie
 FROM ${BASE_IMAGE} AS ruby-base
 
 # Use the same version of Bundler in the Gemfile.lock
-ARG BUNDLER_VERSION=4.0.5
+ARG BUNDLER_VERSION=4.0.6
 ENV BUNDLER_VERSION=${BUNDLER_VERSION}
 
 #--- Builder Stage ---
@@ -16,6 +16,8 @@ FROM ruby-base AS builder
 
 # Install base build packages
 ARG BASE_BUILD_PACKAGES='build-essential libyaml-dev'
+
+ARG BUNDLER_PATH=/usr/local/bundle
 
 # Assumes debian based
 RUN apt-get update \
@@ -25,7 +27,9 @@ RUN apt-get update \
   # Update gem command to latest
   && gem update --system \
   # Install bundler
-  && gem install bundler:${BUNDLER_VERSION}
+  && gem install bundler:${BUNDLER_VERSION} \
+  # Configure bundler to use isolated gem path
+  && bundle config set --local path ${BUNDLER_PATH}
 
 # Install the Ruby dependencies (defined in the Gemfile/Gemfile.lock)
 WORKDIR /app

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GEM
       multi_test (~> 1.1)
       sys-uname (~> 1.3)
     cucumber-ci-environment (11.0.0)
-    cucumber-core (16.1.1)
+    cucumber-core (16.2.0)
       cucumber-gherkin (> 36, < 40)
       cucumber-messages (> 31, < 33)
       cucumber-tag-expressions (> 6, < 9)
@@ -52,11 +52,12 @@ GEM
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
-    irb (1.16.0)
+    irb (1.17.0)
       pp (>= 0.6.0)
+      prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.18.0)
+    json (2.18.1)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -70,9 +71,9 @@ GEM
     page_navigation (0.10)
       data_magic (>= 0.22)
     parallel (1.27.0)
-    parallel_tests (5.5.0)
+    parallel_tests (5.6.0)
       parallel
-    parser (3.3.10.1)
+    parser (3.3.10.2)
       ast (~> 2.4.1)
       racc
     pp (0.6.3)
@@ -85,7 +86,7 @@ GEM
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.3.1)
-    rdoc (7.1.0)
+    rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
       tsort
@@ -106,7 +107,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.7)
-    rubocop (1.84.0)
+    rubocop (1.84.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -135,7 +136,7 @@ GEM
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
     stringio (3.2.0)
-    sys-uname (1.4.1)
+    sys-uname (1.5.0)
       ffi (~> 1.1)
       memoist3 (~> 1.0.0)
     thor (1.5.0)
@@ -173,4 +174,4 @@ RUBY VERSION
   ruby 4.0.1
 
 BUNDLED WITH
-  4.0.5
+  4.0.6


### PR DESCRIPTION
# What & Why

This maintenance changeset updates the project to latest bundler (`4.0.6`) and gems, resolving new rubocop violations.  This maintains currency making future updates less risk.

It also updates the `Dockerfile` to configure bundler to use isolated gem path to avoid dependency version conflicts during `bundle` operations resulting in warnings like these...

```text
root@f1e33713ec17:/app# bundle update --all
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
/usr/local/bundle/gems/rdoc-7.2.0/lib/rdoc/version.rb:8: warning: already initialized constant RDoc::VERSION
/usr/local/lib/ruby/gems/4.0.0/gems/rdoc-7.0.3/lib/rdoc/version.rb:8: warning: previous definition of VERSION was here
/usr/local/bundle/gems/rdoc-7.2.0/lib/rdoc.rb:68: warning: already initialized constant RDoc::VISIBILITIES
/usr/local/lib/ruby/gems/4.0.0/gems/rdoc-7.0.3/lib/rdoc.rb:68: warning: previous definition of VISIBILITIES was here
...
```

# Change Impact Analysis and Testing

- [x] Successful PR Checks verify no regressions
- [x] Performing bundle operation in container results in no warnings
