### PR TITLE
Add VS Code devcontainers Support (Rename BROWSER_TYPE and REMOTE_BROWSER)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+{
+  "name": "Sample Login DevContainer",
+
+  "dockerComposeFile": [
+    "../docker-compose.yml",
+    "../docker-compose.selenium.yml",
+    "../docker-compose.dev.yml"
+  ],
+
+  "service": "browsertests",
+  "workspaceFolder": "/app",
+  "overrideCommand": true,
+
+  // "postStartCommand": "bundle install",
+  "remoteUser": "root",
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "davidanson.vscode-markdownlint",
+        "eamodio.gitlens",
+        "github.vscode-github-actions",
+        "ms-azuretools.vscode-containers",
+        "ms-azuretools.vscode-docker",
+        "ms-vscode-remote.remote-containers",
+        "redhat.vscode-yaml",
+        "shopify.ruby-lsp",
+        "streetsidesoftware.code-spell-checker"
+      ],
+      "settings": {
+        "terminal.integrated.shell.linux": "bash",
+        "ruby.useBundler": true
+      }
+    }
+  },
+
+  "shutdownAction": "stopCompose"
+}

--- a/.github/workflows/on_pr_build_push_vet_images.yml
+++ b/.github/workflows/on_pr_build_push_vet_images.yml
@@ -58,7 +58,7 @@ jobs:
     needs:
       - image-names
       - buildx-and-push-unvetted-image
-    uses: brianjbayer/sample-login-capybara-rspec/.github/workflows/run-e2e-tests.yml@f76bbee64f7fc1b08458c271a7b8e178d0fedea2
+    uses: brianjbayer/sample-login-capybara-rspec/.github/workflows/run-e2e-tests.yml@v0.1
     with:
       e2e_tests_image: ${{ needs.image-names.outputs.unvetted_image }}
       e2e_tests_command: "./script/dockercomposerun -c"
@@ -73,7 +73,7 @@ jobs:
     needs:
       - image-names
       - buildx-and-push-dev-image
-    uses: brianjbayer/sample-login-capybara-rspec/.github/workflows/run-e2e-tests.yml@f76bbee64f7fc1b08458c271a7b8e178d0fedea2
+    uses: brianjbayer/sample-login-capybara-rspec/.github/workflows/run-e2e-tests.yml@v0.1
     with:
       e2e_tests_image: ${{ needs.image-names.outputs.dev_image }}
       e2e_tests_command: "./script/dockercomposerun -d bash -c './wait_on_endpoint && ./script/run -p tests'"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Exclude any environment variable dirs/files in root
 .env*
+
+# IDEs
+.vscode/

--- a/Rakefile
+++ b/Rakefile
@@ -26,7 +26,7 @@ end
 namespace :cucumber do
   desc 'Run Cucumber features in parallel using parallel_tests'
   task :parallel do
-    if ENV['BROWSER'] == 'safari'
+    if ENV['BROWSER_TYPE'] == 'safari'
       warn 'rake: running specs SEQUENTIALLY for safari'
       Rake::Task[:cucumber].invoke
     else

--- a/docker-compose.selenium.yml
+++ b/docker-compose.selenium.yml
@@ -18,8 +18,8 @@ services:
     volumes:
       - /dev/shm:/dev/shm
     ports:
-      - "5900:5900"
-      - "7900:7900"
+      - "${SELENIUM_LOCALHOST_VNC_PORT:-5900}:5900"
+      - "${SELENIUM_LOCALHOST_VNC_WEB_PORT:-7900}:7900"
     environment:
       # The number of browser sessions should correspond to parallelism
       - SE_NODE_MAX_SESSIONS=2

--- a/docker-compose.selenium.yml
+++ b/docker-compose.selenium.yml
@@ -1,9 +1,9 @@
 services:
   browsertests:
     environment:
-      - BROWSER=${BROWSER:-chrome}
+      - BROWSER_TYPE=${BROWSER_TYPE:-chrome}
       - HEADLESS
-      - REMOTE=http://${SELENIUM_HOSTNAME:-seleniumbrowser}:4444/wd/hub
+      - REMOTE_BROWSER=http://${SELENIUM_HOSTNAME:-seleniumbrowser}:4444/wd/hub
       - WAIT_ON_ENDPOINT=${WAIT_ON_ENDPOINT:-http://seleniumbrowser:4444/wd/hub/status}
     depends_on:
       - seleniumbrowser

--- a/docs/RUNNING_NATIVELY.md
+++ b/docs/RUNNING_NATIVELY.md
@@ -33,13 +33,13 @@ see the [PREREQUISITES.md](PREREQUISITES.md)
 
 #### Specify Browser
 
-`BROWSER=`...
+`BROWSER_TYPE=`...
 
 **Example:**
 
-`BROWSER=chrome`
+`BROWSER_TYPE=chrome`
 
-> **If the `BROWSER` environment variable is not provided (i.e. set),
+> **If the `BROWSER_TYPE` environment variable is not provided (i.e. set),
 > then the default Watir (Chrome) browser is used**
 
 Mostly, this uses a _pass-through_ approach and should support any
@@ -77,13 +77,13 @@ The following browsers were working on Mac at the time of this commit...
 
 #### Specify Remote (Container) URL
 
-`REMOTE=`...
+`REMOTE_BROWSER=`...
 
 Specifying a Remote URL creates a remote browser of type
 specified by `BROWSER` at the specified remote URL
 
  **Example:**
-`REMOTE='http://localhost:4444/wd/hub'`
+`REMOTE_BROWSER='http://localhost:4444/wd/hub'`
 
 ### Examples of Running the Tests
 
@@ -100,7 +100,7 @@ bundle exec cucumber
 #### Local Browsers
 
 ```
-BROWSER=firefox HEADLESS=true bundle exec rake
+BROWSER_TYPE=firefox HEADLESS=true bundle exec rake
 ```
 
 #### Using the Selenium Standalone Containers
@@ -122,5 +122,5 @@ For specifics, see the Selenium Standalone Image
 3. Run the tests specifying the remote Selenium container...
 
    ```bash
-   REMOTE='http://localhost:4444/wd/hub' BROWSER=chrome bundle exec cucumber
+   REMOTE_BROWSER='http://localhost:4444/wd/hub' BROWSER_TYPE=chrome bundle exec cucumber
    ```

--- a/docs/RUNNING_WITH_OTHER_CONTAINERS.md
+++ b/docs/RUNNING_WITH_OTHER_CONTAINERS.md
@@ -13,24 +13,24 @@ in the [PREREQUISITES.md](PREREQUISITES.md)
 
 1. Ensure Docker is running
 2. From the project root directory, run the `dockercomposerun`
-   script setting the `BROWSER` and `SELENIUM_IMAGE`
+   script setting the `BROWSER_TYPE` and `SELENIUM_IMAGE`
    environment variables to specify Firefox...
 
    ```bash
-   BROWSER=firefox SELENIUM_IMAGE=selenium/standalone-firefox ./script/dockercomposerun
+   BROWSER_TYPE=firefox SELENIUM_IMAGE=selenium/standalone-firefox ./script/dockercomposerun
    ```
 
 ### To Run Using the Edge Standalone Container
 
 1. Ensure Docker is running
 2. From the project root directory, run the `dockercomposerun`
-   script setting the `BROWSER` and `SELENIUM_IMAGE`
+   script setting the `BROWSER_TYPE` and `SELENIUM_IMAGE`
    environment variables to specify Edge...
 
    **For Intel/x86/amd64 run...**
 
    ```bash
-   BROWSER=edge SELENIUM_IMAGE=selenium/standalone-edge ./script/dockercomposerun
+   BROWSER_TYPE=edge SELENIUM_IMAGE=selenium/standalone-edge ./script/dockercomposerun
    ```
 
    **:apple: For Apple Silicon/arm64...**

--- a/features/support/config.rb
+++ b/features/support/config.rb
@@ -19,11 +19,11 @@ module Config
   # Configuration for Watir-driven browser
   module Watir
     def browser
-      ENV.fetch('BROWSER', nil)
+      ENV.fetch('BROWSER_TYPE', nil)
     end
 
     def remote_browser_url
-      ENV.fetch('REMOTE', nil)
+      ENV.fetch('REMOTE_BROWSER', nil)
     end
 
     def headless?

--- a/script/dockercomposerun
+++ b/script/dockercomposerun
@@ -5,13 +5,14 @@ set -e
 
 usage() {
   cat << USAGE
-Usage: $0 [-cdho] [CMD]
+Usage: $0 [-cdhko] [CMD]
 
 This script orchestrates 'docker compose run browsertests' using the docker compose framework
   * Arguments are passed to the app service as the CMD (entrypoint)
   * Environment variables override app and framework defaults
 
 OPTIONS: (in override order)
+  -k: docker compose down (kills) the specified environment
   -o: Run only the browsertests service (no Selenium Browser)
   -d: Run the docker compose Dev environment
   -c: Run the docker compose CI environment (must specify BROWSERTESTS_IMAGE)
@@ -26,7 +27,7 @@ err_exit() {
 }
 
 # Handle options
-while getopts ":cdho" options; do
+while getopts ":cdhko" options; do
   case "${options}" in
     c)
       ci=1
@@ -36,6 +37,9 @@ while getopts ":cdho" options; do
       ;;
     h)
       usage ; exit
+      ;;
+    k)
+      kill=1
       ;;
     o)
       browsertests_only=1
@@ -65,6 +69,14 @@ echo "DOCKER COMPOSE RUN COMMAND: [${docker_compose_run_command}]"
 
 echo 'DOCKER COMPOSE CONFIGURATION...'
 $docker_compose_command config
+
+if [ -n "${kill}" ] ; then
+  echo 'KILLING: DOCKER-COMPOSE DOWN...'
+  set +e
+  $docker_compose_command down
+  set -e
+  exit
+fi
 
 echo 'DOCKER COMPOSE PULLING...'
 set +e ; $docker_compose_command pull ; set -e

--- a/script/mac-test-native-browsers
+++ b/script/mac-test-native-browsers
@@ -24,8 +24,8 @@ run_command () {
 }
 
 set_browser_env () {
-  export BROWSER="$@"
-  echo "BROWSER=${BROWSER-unset}"
+  export BROWSER_TYPE="$@"
+  echo "BROWSER_TYPE=${BROWSER_TYPE-unset}"
 }
 
 set_headless_env () {


### PR DESCRIPTION
# What & Why

Leverages the existing docker compose framework to add a VS Code *devcontainers* development environment in VS Code.  This is basically the containerized development environment when running `./script/dockercomposerun -d` with the Selenium browser image.  It includes basic extensions such as the Shopify Ruby LSP.

In addition...
* VS Code devcontainers has a preexisting environment variable `BROWSER` the project `BROWSER` and `REMOTE` environment variables were renamed to `BROWSER_TYPE and `REMOTE_BROWSER` respectively
* A new `-k` *kill* option was added to `script\dockercomposerun` to `docker compose down` the running environment (use `./script/dockercomposerun -dk` to stop the  devcontainers stack)

# Change Impact Analysis and Testing

- [x] VS Code devcontainers environment properly starts with extensions
  - [x] In devcontainers terminal window can successfully run tests (`./script/run tests`)
- [x] `./script/mac-test-native-browsers` still runs successfully
- [ ] PR Checks verifies these change and that there are no regressions


